### PR TITLE
Cleanup audit rules

### DIFF
--- a/rules/10-base-config.rules
+++ b/rules/10-base-config.rules
@@ -7,6 +7,3 @@
 
 ## This determine how long to wait in burst of events
 --backlog_wait_time 60000
-
-## Set failure mode to syslog
--f

--- a/rules/30-stig.rules
+++ b/rules/30-stig.rules
@@ -40,8 +40,6 @@
 -a always,exit -F arch=b64 -F path=/etc/hosts -F perm=wa -F key=system-locale
 -a always,exit -F arch=b32 -F path=/etc/hostname -F perm=wa -F key=system-locale
 -a always,exit -F arch=b64 -F path=/etc/hostname -F perm=wa -F key=system-locale
--a always,exit -F arch=b32 -F dir=/etc/NetworkManager/ -F perm=wa -F key=system-locale
--a always,exit -F arch=b64 -F dir=/etc/NetworkManager/ -F perm=wa -F key=system-locale
 
 ## Things that could affect MAC policy
 -a always,exit -F arch=b32 -F dir=/etc/selinux/ -F perm=wa -F key=MAC-policy
@@ -136,7 +134,7 @@
 -a always,exit -F arch=b64 -F path=/usr/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation
 
 ## Always audit call to disable rootfs protection
--a always,exit -F arch=b64 -F path=/usr/local/libexec/disable-rootfs-protection -F perm=x -F auid!=unset -F key=maybe-escalation
+-a always,exit -F arch=b64 -F path=/usr/local/libexec/disable-rootfs-protection -F perm=x -F key=maybe-escalation
 
 ## ZFS-related binares can also be used to bypass system protections.
 -a always,exit -F arch=b64 -F path=/sbin/zfs -F perm=x -F auid>0 -F key=maybe-escalation


### PR DESCRIPTION
Some of rules in base set do not exist in the version of auditd we distribute. A few files in STIG rules do not exist in TrueNAS and prevent auditd load.

This commit also adds an optional prefix argument for script to generate privileged rules. This is due to script being run outside chroot environment in scale_build.