### PR TITLE
NAS-133724 / 25.04 / Write recovery file in audit handler on auditd exit

### DIFF
--- a/scripts/truenas_audit_handler.py
+++ b/scripts/truenas_audit_handler.py
@@ -716,6 +716,11 @@ class AuditdHandler:
         while not self.audis_reader.at_eof():
             await self.handle_auditd_msg()
 
+        # It's possible that auditd has stopped and syslog-ng isn't in
+        # a good state. Write out the recovery file and hope for happier
+        # times after a service restart.
+        await self.loop.run_in_executor(None, self.__write_recovery_file)
+
 
 def __process_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=DESCRIPTION)


### PR DESCRIPTION
If auditd exits and the audit handler script is preparing to exit, it should write out any pending audit messages to the recovery file.