### PR TITLE
NAS-133851 / 25.10 / Add Community Edition audit rules.

### DIFF
--- a/rules/99-finalize.rules
+++ b/rules/99-finalize.rules
@@ -1,2 +1,2 @@
 ## Make the configuration immutable - reboot is required to change audit rules
--e 2
+#-e 2

--- a/rules/99-finalize.rules
+++ b/rules/99-finalize.rules
@@ -1,2 +1,2 @@
 ## Make the configuration immutable - reboot is required to change audit rules
-#-e 2
+-e 2

--- a/rules/truenas-community-edition.rules
+++ b/rules/truenas-community-edition.rules
@@ -11,3 +11,6 @@
 
 ## TrueNAS configuration
 -a always,exit -F arch=b64 -F dir=/data/ -F perm=r -F auid!=unset -F key=escalation
+
+## TrueNAS management
+-a always,exit -F arch=b64 -F path=/usr/bin/incus -F perm=x -F auid!=unset -F key=escalation

--- a/rules/truenas-community-edition.rules
+++ b/rules/truenas-community-edition.rules
@@ -1,6 +1,6 @@
-## These rules are to be applied to TrueNAS Community Edition
+## These rules are to be applied to TrueNAS Non-STIG
 ##
-## These rules quiet the PAM logging
+## Quiet PAM logging
 -A exclude,always -F msgtype=USER_AUTH
 -A exclude,always -F msgtype=USER_START
 -A exclude,always -F msgtype=USER_END
@@ -8,3 +8,6 @@
 -A exclude,always -F msgtype=CRED_REFR
 -A exclude,always -F msgtype=CRED_DISP
 -A exclude,always -F msgtype=CRED_ACQ
+
+## TrueNAS configuration
+-a always,exit -F arch=b64 -F dir=/data/ -F perm=r -F auid!=unset -F key=escalation

--- a/rules/truenas-community-edition.rules
+++ b/rules/truenas-community-edition.rules
@@ -1,0 +1,10 @@
+## These rules are to be applied to TrueNAS Community Edition
+##
+## These rules quiet the PAM logging
+-A exclude,always -F msgtype=USER_AUTH
+-A exclude,always -F msgtype=USER_START
+-A exclude,always -F msgtype=USER_END
+-A exclude,always -F msgtype=USER_ACCT
+-A exclude,always -F msgtype=CRED_REFR
+-A exclude,always -F msgtype=CRED_DISP
+-A exclude,always -F msgtype=CRED_ACQ

--- a/scripts/truenas_audit_handler.py
+++ b/scripts/truenas_audit_handler.py
@@ -243,6 +243,12 @@ class AuditMsgService(AuditMsgParser):
 
 
 class AuditMsgPamBase(AuditMsgParser):
+    """
+    Parser for messsages associated with PAM
+
+    Sample entry:
+    type=CRED_DISP msg=audit(1738184696.902:276470): pid=1389074 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg='op=PAM:setcred grantors=pam_rootok acct="truenas_admin" exe="/usr/bin/su" hostname=? addr=? terminal=/dev/pts/0 res=success'
+    """
     PID = (2, int)
     FUNCTION = (7, str)
 


### PR DESCRIPTION
Add Community Edition rule set.

This initial set of rules for TrueNAS Community Edition quiets PAM audit logging.

There is a companion PR in middleware.