### PR TITLE
NAS-134820 / 25.04.0 / Add exclude of SERVICE_START and SERVICE_STOP for community rules. (by mgrimesix)

### DIFF
--- a/rules/truenas-community-edition.rules
+++ b/rules/truenas-community-edition.rules
@@ -8,6 +8,9 @@
 -A exclude,always -F msgtype=CRED_REFR
 -A exclude,always -F msgtype=CRED_DISP
 -A exclude,always -F msgtype=CRED_ACQ
+## Quiet SERVICE_START and SERVICE_STOP
+-A exclude,always -F msgtype=SERVICE_START
+-A exclude,always -F msgtype=SERVICE_STOP
 
 ## TrueNAS configuration
 -a always,exit -F arch=b64 -F dir=/data/ -F perm=r -F auid!=unset -F key=escalation


### PR DESCRIPTION
The SERVICE_START and SERVICE_STOP generate a great deal of messages that drown out potentially interesting and useful messages.    This PR squashes the reporting of SERVICE_START and SERVICE_STOP messages for `community edition` only.

This PR has companion PRs in middleware and ixdiagnose.

Original PR: https://github.com/truenas/audit_rules/pull/13
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134820