### PR TITLE
NAS-137308 / 26.04 / STIG: add nginx auditd rules

### DIFF
--- a/rules/truenas-stig.rules
+++ b/rules/truenas-stig.rules
@@ -4,5 +4,5 @@
 ## configuration and control
 -a exit,always -F arch=b64 -S all -F dir=/etc/nginx -F auid!=unset -k escalation
 ## logs
--a exit,always -F arch=b64 -F path=/var/log/nginx/access.log -F perm=wa -F euid!=33 -k escalation
--a exit,always -F arch=b64 -F path=/var/log/nginx/error.log -F perm=wa -F euid!=33 -k escalation
+-a exit,always -F arch=b64 -F path=/var/log/nginx/access.log -F perm=wa -F auid!=unset -F euid!=33 -k escalation
+-a exit,always -F arch=b64 -F path=/var/log/nginx/error.log -F perm=wa -F auid!=unset -F euid!=33 -k escalation

--- a/rules/truenas-stig.rules
+++ b/rules/truenas-stig.rules
@@ -1,0 +1,8 @@
+## These are TrueNAS specific rules for STIG
+## 
+## ---- nginx ----
+## configuration and control
+-a exit,always -F arch=b64 -S all -F dir=/etc/nginx -F auid!=unset -k escalation
+## logs
+-a exit,always -F arch=b64 -F path=/var/log/nginx/access.log -F perm=wa -F euid!=33 -k escalation
+-a exit,always -F arch=b64 -F path=/var/log/nginx/error.log -F perm=wa -F euid!=33 -k escalation


### PR DESCRIPTION
STIG mode requires auditing nginx.

This PR:
- Adds truenas STIG rules file: `truenas-stig.rules`
- Populate the `truenas-stig.rules` file with nginx auditing rules
-- Audit the nginx configuration directory and files
-- Audit the nginx logs

This PR has a companion middleware PR with the same named branch.

CI tests are included in the middleware PR.