### PR TITLE
NAS-138438 / 26.04 / Protect rule generation against circular links

### DIFF
--- a/rules/privileged-rules.py
+++ b/rules/privileged-rules.py
@@ -54,8 +54,8 @@ def generate_audit_privilege(target_dir: str, privilege_file: str, prefix: str) 
                         write_audit_entry(target, f, prefix)
                 except FileNotFoundError:
                     pass  # possibly broken symlink
-                except OSError as os_e:
-                    if os_e.errno == 40:
+                except OSError as e:
+                    if e.errno == 40:
                         pass  # avoid circular link
 
         f.flush()

--- a/rules/privileged-rules.py
+++ b/rules/privileged-rules.py
@@ -53,8 +53,10 @@ def generate_audit_privilege(target_dir: str, privilege_file: str, prefix: str) 
                     if file_has_setuid_bit(target) or file_has_capability(target):
                         write_audit_entry(target, f, prefix)
                 except FileNotFoundError:
-                    # possibly broken symlink
-                    pass
+                    pass  # possibly broken symlink
+                except OSError as OSe:
+                    if OSe.errno == 40:
+                        pass  # avoid circular link
 
         f.flush()
 
@@ -66,13 +68,13 @@ def main():
         help='Target directory in which to find privileged files.'
     )
     parser.add_argument(
-       '-p', '--privilege_file',
-       help='File in which to write privilege rules.'
+        '-p', '--privilege_file',
+        help='File in which to write privilege rules.'
     )
     parser.add_argument(
-       '-x', '--prefix',
-       help='File in which to write privilege rules.',
-       default=''
+        '-x', '--prefix',
+        help='File in which to write privilege rules.',
+        default=''
     )
 
     args = parser.parse_args()

--- a/rules/privileged-rules.py
+++ b/rules/privileged-rules.py
@@ -2,6 +2,7 @@
 
 import argparse
 import errno
+import sys
 
 from io import TextIOWrapper
 from os import listxattr, path, stat, walk
@@ -59,10 +60,10 @@ def generate_audit_privilege(target_dir: str, privilege_file: str, prefix: str) 
                     if os_e.errno == errno.ELOOP:
                         pass  # avoid circular link
                     else:
-                        print(f"Detected unhandled OSError in auditd privileged rule file generation: {os_e}")
+                        print(f"Detected unhandled OSError in auditd privileged rule file generation: {os_e}", file=sys.stderr)
                 except Exception as e:
                     # Unexpected error.  Skip this file, but record the event.
-                    print(f"Detected error in auditd privileged rule file generation: {e}")
+                    print(f"Detected error in auditd privileged rule file generation: {e}", file=sys.stderr)
 
         f.flush()
 

--- a/rules/privileged-rules.py
+++ b/rules/privileged-rules.py
@@ -54,8 +54,8 @@ def generate_audit_privilege(target_dir: str, privilege_file: str, prefix: str) 
                         write_audit_entry(target, f, prefix)
                 except FileNotFoundError:
                     pass  # possibly broken symlink
-                except OSError as OSe:
-                    if OSe.errno == 40:
+                except OSError as os_e:
+                    if os_e.errno == 40:
                         pass  # avoid circular link
 
         f.flush()


### PR DESCRIPTION
Add exception handler for circular links.

The rule generation script will get stuck if it attempts to process a circular link.  This results in a corrupted rule file.
This is a more rare condition, but has happened.   The directory `/run/udev/watch` is notorious for containing circular links.

Also fixed indentation issue on the parser argument lines.