### PR TITLE
NAS-138439 / 26.04 / Remove /etc/exports.d from the GPOS STIG audit list.

### DIFF
--- a/rules/30-stig.rules
+++ b/rules/30-stig.rules
@@ -148,7 +148,6 @@
 
 ## Server configuration
 -a always,exit -F arch=b64 -F path=/etc/exports -F perm=wa -F auid!=unset -F key=export
--a always,exit -F arch=b64 -F dir=/etc/exports.d -F perm=wa -F auid!=unset -F key=export
 -a always,exit -F arch=b64 -F path=/etc/smb4.conf -F perm=wa -F auid!=unset -F key=export
 -a always,exit -F arch=b64 -F path=/etc/proftpd/proftpd.conf -F perm=wa -F auid!=unset -F key=export
 -a always,exit -F arch=b64 -F dir=/etc/proftpd/conf.d -F perm=wa -F auid!=unset -F key=export


### PR DESCRIPTION
Including this directory can result in a corrupted set of active audit rules.
We've completely disabled using directories to hold NFS share configuration in a companion [PR](https://github.com/truenas/nfs-utils/pull/9).