### PR TITLE
NAS-138528 / 26.04 / Avoid error messages at shutdown or restart.

### DIFF
--- a/scripts/truenas_audit_handler.py
+++ b/scripts/truenas_audit_handler.py
@@ -719,7 +719,7 @@ class AuditdHandler:
         # The auditd systemd unit upholds this script and
         # so exit run loop if we get EOF. When auditd comes
         # back it will start this script back up.
-        while not self.audis_reader.at_eof():
+        while self.audis_reader is not None and not self.audis_reader.at_eof():
             await self.handle_auditd_msg()
 
         # It's possible that auditd has stopped and syslog-ng isn't in


### PR DESCRIPTION
The TrueNAS audit handler was generating errors on shutdown or restart:
```
Nov 12 13:18:13 truenas systemd[1]: Stopping tnaudit.service - TrueNAS Auditd Handler...
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]: Traceback (most recent call last):
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:   File "/usr/local/libexec/truenas_audit_handler.py", line 774, in <module>
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:     finally:
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:     ^^^^^^
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:   File "/usr/local/libexec/truenas_audit_handler.py", line 770, in main
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:     )
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:   File "/usr/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:     return future.result()
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:            ~~~~~~~~~~~~~^^
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:   File "/usr/local/libexec/truenas_audit_handler.py", line 722, in run
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:     while not self.audis_reader.at_eof():
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]:               ^^^^^^^^^^^^^^^^^^^^^^^^
Nov 12 13:18:13 truenas truenas_audit_handler.py[33158]: AttributeError: 'NoneType' object has no attribute 'at_eof'
Nov 12 13:18:13 truenas systemd[1]: tnaudit.service: Main process exited, code=exited, status=1/FAILURE
Nov 12 13:18:13 truenas systemd[1]: tnaudit.service: Failed with result 'exit-code'.
```
This PR fixes that.