### PR TITLE
NAS-139112 / 26.04 / Add PAM authentication to commmunity rules

### DIFF
--- a/rules/truenas-community-edition.rules
+++ b/rules/truenas-community-edition.rules
@@ -1,7 +1,6 @@
 ## These rules are to be applied to TrueNAS Non-STIG
 ##
 ## Quiet PAM logging
--A exclude,always -F msgtype=USER_AUTH
 -A exclude,always -F msgtype=USER_START
 -A exclude,always -F msgtype=USER_END
 -A exclude,always -F msgtype=USER_ACCT


### PR DESCRIPTION
This allows us to more readily capture failed / successful authentication attempts via SSH and other PAM-enabled services.