### PR TITLE
NAS-138844 / 26.0.0-BETA.1 / Add diagnostic logging using middleware logger infrastructure.

### DIFF
--- a/scripts/truenas_audit_handler.py
+++ b/scripts/truenas_audit_handler.py
@@ -15,7 +15,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from collections import defaultdict, deque
 from json import dumps
-from middlewared.logger import TNSyslogHandler
+from middlewared.logger import (
+    TNSyslogHandler, TNLog, DEFAULT_LOGFORMAT, AUDIT_HANDLER_LOGFILE, QFORMATTER
+)
 from queue import Queue
 from random import getrandbits
 from uuid import UUID
@@ -30,6 +32,7 @@ DESCRIPTION = (
 DEFAULT_AUDISPD_SOCK = '/var/run/audispd_events'
 DEFAULT_SYSLOG_SOCK = '/var/run/syslog-ng/auditd.sock'
 DEFAULT_RECOVERY_FILE = '/var/run/middleware/.auditd_handler.recovery'
+DEFAULT_DIAG_SYSLOG_SOCK = '/var/run/syslog-ng/audit_handler.sock'
 SYSLOG_IDENT = 'TNAUDIT_SYSTEM: '
 AUDITD_LINE_SEPARATOR = '\x1d'
 AUDITD_NULL_VALUES = frozenset(['(null)', '(none)', '?', 'unset'])
@@ -40,6 +43,17 @@ PAM_SPLIT_PATTERN = re.compile(r'(?=\b(?:grantors|acct|exe|hostname|addr|termina
 # TODO: generate critical middleware alert if our backlog starts to hit
 # critical levels
 ALERT_QUEUE_DEPTH = 1024
+
+# Diagnostic logging configuration for the audit handler daemon
+# This creates a separate log file for operational/diagnostic logging
+# The logfile path is defined in middlewared/logger.py and automatically
+# configured in syslog-ng via Mako templates
+AUDIT_HANDLER_LOG = TNLog(
+    name='audit_handler',
+    logfile=AUDIT_HANDLER_LOGFILE,
+    logformat=DEFAULT_LOGFORMAT,
+    pending_maxlen=1024
+)
 
 
 class AuditMsgParser(enum.Enum):
@@ -639,6 +653,67 @@ def audit_entry_to_json(msgid: str, entry: AUDITEntry) -> str:
     return '@cee:' + dumps(to_write)
 
 
+def setup_syslog_handler_custom_socket(
+    tnlog: TNLog,
+    fallback: logging.Handler | None,
+    socket_path: str
+) -> logging.Logger:
+    """
+    Create a syslog handler using middleware infrastructure but with a custom socket.
+
+    This is a replacement for the middleware setup_syslog_handler that allows
+    specifying a different syslog-ng socket path. The function replicates the
+    middleware's setup_syslog_handler behavior but creates the TNSyslogHandler
+    with a custom socket address.
+
+    Args:
+        tnlog: TNLog configuration object from middleware
+        fallback: Optional fallback handler for when syslog is unavailable
+        socket_path: Path to the syslog-ng Unix socket
+
+    Returns:
+        Configured logger instance
+    """
+    # Use QueueHandler to avoid blocking IO in asyncio main loop
+    log_queue = Queue()
+    queue_handler = logging.handlers.QueueHandler(log_queue)
+
+    # Format python exceptions into structured data
+    queue_handler.setFormatter(QFORMATTER)
+
+    # Create syslog handler with custom socket path and pending queue
+    syslog_handler = TNSyslogHandler(
+        address=socket_path,
+        pending_queue=deque(maxlen=tnlog.pending_maxlen)
+    )
+    syslog_handler.setLevel(logging.DEBUG)
+
+    # Apply log format if specified
+    if tnlog.logformat:
+        syslog_handler.setFormatter(
+            logging.Formatter(tnlog.logformat, '%Y/%m/%d %H:%M:%S')
+        )
+
+    # Set ident for syslog-ng filtering
+    syslog_handler.ident = tnlog.get_ident()
+
+    # Set fallback handler if provided
+    if fallback:
+        syslog_handler.set_fallback_handler(fallback)
+
+    # Start queue listener in separate thread
+    queue_listener = logging.handlers.QueueListener(log_queue, syslog_handler)
+    queue_listener.start()
+
+    # Configure and return logger
+    logger = logging.getLogger(tnlog.name)
+    logger.addHandler(queue_handler)
+    if tnlog.name is not None:
+        logging.getLogger(tnlog.name).propagate = False
+
+    return logger
+
+
 class AuditdHandler:
     def __init__(
         self,
@@ -649,12 +724,14 @@ class AuditdHandler:
     ):
         self.exit = False
         self.loop = loop
-        self.logger = None
+        self.logger = None  # Audit event logger (writes JSON audit events)
+        self.diag_logger = None  # Diagnostic logger (writes operational logs)
         self.syslog_handler = None
         self.audis_path = audis_sock
         self.syslog_path = syslog_sock
         self.recovery_file = recovery_file
         self.syslog_queue_listener = None
+        self.diag_queue_listener = None
         self.audis_reader = None
         self.audis_writer = None
         self.partial_records = defaultdict(AUDITEntry)
@@ -680,38 +757,81 @@ class AuditdHandler:
         self.syslog_hander = audit_handler
         self.syslog_queue_listener = queue_listener
 
+        # Set up separate diagnostic logger for operational/daemon logging
+        # This creates a separate log file for troubleshooting the handler itself
+        fallback_handler = logging.handlers.RotatingFileHandler(
+            '/var/log/audit/audit_handler_fallback.log',
+            'a',
+            10485760,  # 10MB
+            5,         # 5 backups
+            'utf-8'
+        )
+        fallback_handler.setLevel(logging.DEBUG)
+        fallback_handler.setFormatter(logging.Formatter(DEFAULT_LOGFORMAT, '%Y/%m/%d %H:%M:%S'))
+
+        # Use custom socket path for diagnostic logger to avoid middleware.sock
+        # This "patches" the logger to use a different syslog-ng socket
+        # while still leveraging the middleware logging infrastructure
+        self.diag_logger = setup_syslog_handler_custom_socket(
+            AUDIT_HANDLER_LOG,
+            fallback_handler,
+            DEFAULT_DIAG_SYSLOG_SOCK
+        )
+        self.diag_logger.setLevel(logging.DEBUG)
+        self.diag_logger.info("Audit handler diagnostic logging initialized")
+
     def __write_recovery_file(self):
+        queue_len = len(self.pending_queue)
+        if queue_len == 0:
+            self.diag_logger.debug("No pending messages to write to recovery file")
+            return
+
+        self.diag_logger.warning("Writing %r pending messages to recovery file", self.recovery_file)
         with open(self.recovery_file, 'w') as f:
             while self.pending_queue:
                 record = self.pending_queue.popleft()
                 f.write(f'{record.msg}\n')
 
             f.flush()
+        self.diag_logger.info("Recovery file written successfully with %d messages", queue_len)
 
     def __read_recovery_file(self):
         # read our recovery file into the pending queue and then remove it.
         if not os.path.exists(self.recovery_file):
+            self.diag_logger.debug("No recovery file found at %r", self.recovery_file)
             return
 
+        self.diag_logger.info("Recovery file found at %r, replaying messages", self.recovery_file)
+        msg_count = 0
         with open(self.recovery_file, 'r') as f:
             for line in f:
                 # immediately emit events in recovery file
                 self.logger.critical(line)
+                msg_count += 1
 
         os.unlink(self.recovery_file)
+        self.diag_logger.info("Replayed %d messages from recovery file", msg_count)
 
     def terminate(self):
+        self.diag_logger.info("Received termination signal, shutting down audit handler")
         # By this point our logger has shut down, but we may have a queue.
         self.__write_recovery_file()
 
         # Setting our reader / writer to None breaks out of loop
         self.audis_reader = None
         self.audis_writer = None
+        self.diag_logger.info("Audit handler terminated")
 
     async def __setup_reader(self) -> None:
-        r, w = await asyncio.open_unix_connection(path=self.audis_path)
-        self.audis_reader = r
-        self.audis_writer = w
+        self.diag_logger.info("Connecting to audispd socket at %r", self.audis_path)
+        try:
+            r, w = await asyncio.open_unix_connection(path=self.audis_path)
+            self.audis_reader = r
+            self.audis_writer = w
+            self.diag_logger.info("Successfully connected to audispd socket")
+        except Exception:
+            self.diag_logger.exception("Failed to connect to audispd socket.")
+            raise
 
     async def send_completed(self, msgid: str, data: AUDITEntry) -> None:
         json_data = audit_entry_to_json(msgid, data)
@@ -719,7 +839,12 @@ class AuditdHandler:
 
     async def parse_audit_line(self, line: bytes):
         # decode and strip off trailing newline character
-        decoded = line.decode()[0:-1]
+        try:
+            decoded = line.decode()[0:-1]
+        except Exception:
+            self.diag_logger.exception("Failed to decode audit line.")
+            return
+
         if not decoded:
             return
 
@@ -754,19 +879,31 @@ class AuditdHandler:
         if (completed := await self.parse_audit_line(data)) is not None:
             await self.send_completed(*completed)
 
+            # Monitor pending queue depth and warn if getting high
+            # TODO: Add alert messages
+            queue_depth = len(self.pending_queue)
+            if queue_depth >= ALERT_QUEUE_DEPTH:
+                self.diag_logger.critical("Pending queue depth critical: %d messages queued", queue_depth)
+            elif queue_depth >= ALERT_QUEUE_DEPTH * 0.75:
+                self.diag_logger.warning("Pending queue depth high: %d messages queued", queue_depth)
+
     def __setup_signal_handlers(self):
         self.loop.add_signal_handler(signal.SIGTERM, self.terminate)
         self.loop.add_signal_handler(signal.SIGINT, self.terminate)
 
     async def run(self):
+        self.diag_logger.info("Starting audit handler main loop")
         await self.__setup_reader()
         self.__setup_signal_handlers()
+        self.diag_logger.info("Audit handler ready (audispd=%r, syslog=%r)", self.audis_path, self.syslog_path)
 
         # The auditd systemd unit upholds this script and
         # so exit run loop if we get EOF. When auditd comes
         # back it will start this script back up.
         while self.audis_reader is not None and not self.audis_reader.at_eof():
             await self.handle_auditd_msg()
+
+        self.diag_logger.warning("EOF received from audispd socket, stopping main loop")
 
         # It's possible that auditd has stopped and syslog-ng isn't in
         # a good state. Write out the recovery file and hope for happier
@@ -795,8 +932,11 @@ def __process_args() -> argparse.Namespace:
 
 
 def __validate_socket_path(path: str):
-    if not stat.S_ISSOCK(os.stat(path).st_mode):
-        raise RuntimeError(f'{path}: not a socket.')
+    try:
+        if not stat.S_ISSOCK(os.stat(path).st_mode):
+            raise RuntimeError(f'{path}: not a socket.')
+    except FileNotFoundError:
+        raise RuntimeError(f'{path}: socket does not exist')
 
 
 def __validate_args(args: argparse.Namespace):
@@ -814,11 +954,21 @@ def main():
         args.recovery_file,
         loop
     )
+    handler.diag_logger.info("TrueNAS audit handler starting (pid=%d)", os.getpid())
+    handler.diag_logger.info(
+        "Configuration: audispd=%r, syslog=%r, recovery=%r", args.audit_socket, args.syslog_socket, args.recovery_file
+    )
+
     asyncio.set_event_loop(loop)
     try:
         loop.run_until_complete(handler.run())
+    except Exception:
+        handler.diag_logger.exception("Fatal error in main loop.")
+        raise
     finally:
+        handler.diag_logger.info("Cleaning up and closing event loop")
         loop.close()
+        handler.diag_logger.info("Audit handler exited")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The audit handler has no capability to log its own status.   This PR adds logging capability to the audit handler.
The middleware logging infrastructure is utilized.
A 'fallback' logger is also configured.

This does not trace audit events.  It's purpose is to log start and stop and anomalous audit handling.

Includes some initial logging.