### PR TITLE
NAS-139610 / 26.0.0-BETA.1 / Fix pam parsing

### DIFF
--- a/scripts/truenas_audit_handler.py
+++ b/scripts/truenas_audit_handler.py
@@ -468,10 +468,11 @@ def __parse_pam(msg_type: str, msg_parts: list) -> dict:
             value = ' '.join([value] + variable_parts[i+1:j])
 
         # Strip quotes if present
-        if value and value[0] == '"':
-            value = value[1:]
-        if value and value[-1] == '"':
-            value = value[:-1]
+        if value:
+            if value[0] == '"':
+                value = value[1:]
+            if value[-1] == '"':
+                value = value[:-1]
 
         # Convert to appropriate type
         if value.isdigit():


### PR DESCRIPTION
PAM validation of local commands introduces an auditd message with a 'hostname' that is incompatible with the usual key=value pairs:

`type=USER_AUTH msg=audit(1770076233.944:455): pid=37114 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg='op=PAM:authentication grantors=pam_access acct="root" exe="/usr/bin/python3.13" hostname=UNIX socket (pid=77953 uid=0 gid=0) addr=? terminal=? res=success'UID="root" AUID="unset" UID="root" GID="root"`

Every auditd message is space delimited split into key=value pairs which are then reformatted into a TrueNAS audit entry.
However, starting in Halfmoon, the 'USER_AUTH' entry for local commands, e.g. root user in a shell, generate auditd entries formatted as shown above.
The `hostname` value is not encapsulated in double quotes, contains spaces and has its own set of key=value pairs.  Parsing this under the simple space delimited split and key=value pair processing generates an exception and forces a restart of truenas_audit_handler.

This PR includes a fix for this.

There will be a follow on PR for this module that that targets general improvements to add logging and try blocks.
