### PR TITLE
Convert audit parser script to use upstream library

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,38 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            debhelper \
+            dh-python \
+            pybuild-plugin-pyproject \
+            python3-all-dev \
+            python3-setuptools \
+            python3-build \
+            python3-installer \
+            python3-pytest \
+            libaudit-dev \
+            libauparse-dev
+
+      - name: Build debian package
+        run: dpkg-buildpackage -us -uc -b
+
+      - name: Install debian package
+        run: sudo dpkg --force-depends -i ../truenas-audit-rules_*.deb
+
+      - name: Run tests
+        run: python3 -m pytest tests/ -v

--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,19 @@ Source: truenas-audit-rules
 Section: admin
 Priority: optional
 Maintainer: Andrew Walker <awalker@ixsystems.com>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 12),
+               dh-python,
+               pybuild-plugin-pyproject,
+               python3-all-dev,
+               python3-setuptools,
+               python3-build,
+               python3-installer,
+               libaudit-dev,
+               libauparse-dev
 Standards-Version: 4.4.0
 Homepage: http://www.truenas.com
 
 Package: truenas-audit-rules
 Architecture: any
-Depends: python3:any, truenas-files, ${misc:Depends}, ${shlibs:Depends}
-Description: Auditd rules for TrueNAS when STIG compatibiliy mode
- enabled.
+Depends: python3:any, truenas-files, ${misc:Depends}, ${shlibs:Depends}, ${python3:Depends}
+Description: Auditd rules and audit event handler for TrueNAS

--- a/debian/rules
+++ b/debian/rules
@@ -1,23 +1,15 @@
 #!/usr/bin/make -f
-#export DH_VERBOSE = 1
+export PYBUILD_NAME=truenas_audit
+export PYBUILD_SYSTEM=pyproject
 
 %:
-	dh $@
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_install:
-	sh -c "\
-		mkdir -p debian/truenas-audit-rules/conf/audit_rules/; \
-		cp -a rules/* debian/truenas-audit-rules/conf/audit_rules/; \
-		mkdir -p debian/truenas-audit-rules/conf/audit_plugins/; \
-		cp -a plugins/* debian/truenas-audit-rules/conf/audit_plugins/; \
-		mkdir -p debian/truenas-audit-rules/usr/local/libexec/; \
-		cp -a scripts/* debian/truenas-audit-rules/usr/local/libexec/; \
-		mkdir -p debian/truenas-audit-rules/lib/systemd/system/; \
-		cp -a systemd/* debian/truenas-audit-rules/lib/systemd/system/; \
-	"
-
-override_dh_fixperms:
-
-override_dh_shlibdeps:
-
-override_dh_usrlocal:
+	dh_auto_install
+	mkdir -p debian/truenas-audit-rules/conf/audit_rules/
+	cp -a rules/* debian/truenas-audit-rules/conf/audit_rules/
+	mkdir -p debian/truenas-audit-rules/conf/audit_plugins/
+	cp -a plugins/* debian/truenas-audit-rules/conf/audit_plugins/
+	mkdir -p debian/truenas-audit-rules/lib/systemd/system/
+	cp -a systemd/* debian/truenas-audit-rules/lib/systemd/system/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "truenas_audit"
+version = "0.1.0"
+description = "TrueNAS audit event parsing via libauparse"
+requires-python = ">=3.11"
+license = {text = "LGPL-3.0-or-later"}
+
+[project.scripts]
+truenas_audit_handler = "_truenas_audit_scripts.truenas_audit_handler:main"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026

--- a/scripts/truenas_audit_handler.py
+++ b/scripts/truenas_audit_handler.py
@@ -1,27 +1,31 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
 
 import argparse
 import asyncio
-import enum
 import logging
 import logging.handlers
 import os
-import re
 import signal
 import stat
+import time
 
-from codecs import decode
-from dataclasses import dataclass, field
-from datetime import datetime
-from collections import defaultdict, deque
-from json import dumps
+from truenas_api_client import Client
+
+from collections import deque
 from middlewared.logger import (
     TNSyslogHandler, TNLog, DEFAULT_LOGFORMAT, AUDIT_HANDLER_LOGFILE, QFORMATTER
 )
 import socket
 from queue import Queue
-from random import getrandbits
-from uuid import UUID
+
+import truenas_auparse
+from truenas_audit_parse import (
+    audit_entry_to_json, classify_event,
+)
+from truenas_audit_parse.constants import AUDITD_LINE_SEPARATOR
+from truenas_audit_parse.event_types import AuditMsgEventType
 
 
 DESCRIPTION = (
@@ -38,11 +42,10 @@ DEFAULT_RECOVERY_FILE = '/var/run/middleware/.auditd_handler.recovery'
 diag_logger = None
 DEFAULT_DIAG_SYSLOG_SOCK = '/dev/log'
 SYSLOG_IDENT = 'TNAUDIT_SYSTEM: '
-AUDITD_LINE_SEPARATOR = '\x1d'
-AUDITD_NULL_VALUES = frozenset(['(null)', '(none)', '?', 'unset'])
-JSON_NULL = 'null'
 
-PAM_SPLIT_PATTERN = re.compile(r'(?=\b(?:grantors|acct|exe|hostname|addr|terminal|res|UID|AUID|ID|GID)=)')
+ENTERPRISE_CHECK_TIMEOUT = 60    # seconds to retry initial middlewared connection
+ENTERPRISE_CHECK_INTERVAL = 2    # seconds between retries during initial check
+ENTERPRISE_RECHECK_INTERVAL = 300  # seconds between polls in the CE no-op loop
 
 # TODO: generate critical middleware alert if our backlog starts to hit
 # critical levels
@@ -58,629 +61,6 @@ AUDIT_HANDLER_LOG = TNLog(
     logformat=DEFAULT_LOGFORMAT,
     pending_maxlen=1024
 )
-
-
-class AuditMsgParser(enum.Enum):
-    @property
-    def idx(self) -> int:
-        return self.value[0]
-
-    @property
-    def data_type(self) -> type:
-        return self.value[1]
-
-    def get_entry(self, data: list[str]) -> tuple:
-        key, value = data[self.idx].split('=', 1)
-        if self.data_type is str:
-            # possibly strip leading and trailing quotes
-            if value[0] == '"':
-                value = value[1:]
-            if value[-1] == '"':
-                value = value[:-1]
-
-            # We may have literal string denoting a NULL value change back to
-            # python None type, which will then be encoded as JSON NULL when
-            # encoded for DB insertion.
-            if value in AUDITD_NULL_VALUES:
-                value = None
-
-            return (key, value)
-
-        elif self.data_type is bool:
-            return (key, value == "yes")
-
-        return (key, int(value))
-
-
-class AuditMsgBase(AuditMsgParser):
-    TYPE = (0, str)
-    ID = (1, str)
-
-    def get_entry(self, data: list[str]) -> tuple:
-        if self is AuditMsgBase.TYPE:
-            return super().get_entry(data)
-
-        key, value = data[self.idx].split('=', 1)
-        # ID has a trailing colon ":" that needs to be stripped
-        return (key, value[0: -1])
-
-
-def get_msg_type(data: list[str]) -> str:
-    key, value = AuditMsgBase.TYPE.get_entry(data)
-    return value
-
-
-def get_msg_id(data: list[str]) -> str:
-    key, value = AuditMsgBase.ID.get_entry(data)
-    return value
-
-
-class AuditMsgPath(AuditMsgParser):
-    """
-    Parser for path type entry
-
-    Sample entry:
-    "type=PATH msg=audit(1734547436.320:852): item=1 name=\"/usr/local/libexec/disable-rootfs-protection\" inode=46471 dev=00:23 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 OUID=\"root\" OGID=\"root\""  # noqa
-    """
-    NAME = (3, str)
-    INODE = (4, int)
-    DEV = (5, str)
-    MODE = (6, str)
-    OUID = (7, int)
-    OGID = (8, int)
-    RDEV = (9, str)
-    NAMETYPE = (10, str)
-
-
-class AuditMsgMissingPath(AuditMsgParser):
-    """
-    Parser for path type entry when file doesn't exist or can't be accessed.
-    In this case, inode, dev, mode, ouid, ogid, and rdev fields are missing.
-
-    Sample entry:
-    "type=PATH msg=audit(01/16/26 10:14:05.973:834) : item=0 name=/etc/exports.d nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0"  # noqa
-    """
-    NAME = (3, str)
-    NAMETYPE = (4, str)
-
-
-class AuditMsgProctitle(AuditMsgParser):
-    """
-    Parser for PROCTITLE type messages
-
-    Sample entry:
-    "type=PROCTITLE msg=audit(1734547436.320:852): proctitle=2F7573722F62696E2F707974686F6E33002F7573722F6C6F63616C2F6C6962657865632F64697361626C652D726F6F7466732D70726F74656374696F6E"  # noqa
-    """
-    PROCTITLE = (2, str)
-
-    def get_entry(self, data: list[str]) -> tuple:
-        key, value = super().get_entry(data)
-
-        # Although userspace library guidelines state to hex-encode this value
-        # some libaudit consumers break (notably pam_tty_audit) break this expectation.
-        # If we fail to decode simply put original string in message.
-        try:
-            proc = decode(value, 'hex').decode().replace('\x00', ' ')
-        except Exception:
-            proc = value
-
-        return (key, proc)
-
-
-class AuditMsgCwd(AuditMsgParser):
-    """
-    Parser for CWD type messages
-
-    Sample entry:
-    "type=CWD msg=audit(1734547436.320:852): cwd=\"/root\""
-    """
-    CWD = (2, str)
-
-
-class AuditMsgSyscall(AuditMsgParser):
-    """
-    Parser for SYSCALL type messages
-
-    Sample entry:
-    "type=SYSCALL msg=audit(1734547436.320:852): arch=c000003e syscall=59 success=yes exit=0 a0=7fb27f458c70 a1=7fb27f458ce0 a2=56289c566760 a3=8 items=4 ppid=10424 pid=11969 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts2 ses=12 comm=\"disable-rootfs-\" exe=\"/usr/bin/python3.11\" subj=unconfined key=\"escalation\" ARCH=x86_64 SYSCALL=execve AUID=\"root\" UID=\"root\" GID=\"root\" EUID=\"root\" SUID=\"root\" FSUID=\"root\" EGID=\"root\" SGID=\"root\" FSGID=\"root\"  # noqa
-    """
-    SUCCESS = (4, bool)
-    EXIT = (5, int)
-    PPID = (11, int)
-    PID = (12, int)
-    AUID = (13, int)
-    UID = (14, int)
-    GID = (15, int)
-    EUID = (16, int)
-    SUID = (17, int)
-    FSUID = (18, int)
-    EGID = (19, int)
-    SGID = (20, int)
-    FSGID = (21, int)
-    TTY = (22, str)
-    SES = (23, int)
-    KEY = (27, str)
-    SYSCALL_STR = (29, str)
-    AUID_STR = (30, str)
-    UID_STR = (31, str)
-    GID_STR = (32, str)
-
-
-class AuditMsgSyscallNoRval(AuditMsgParser):
-    """
-    Some syscall entries do not have a proper exit code
-
-    Sample entry:
-    type=SYSCALL msg=audit(1735072331.659:2032): arch=c000003e syscall=231 a0=0 a1=e7 a2=3c a3=7ffd914e4b20 items=0 ppid=42401 pid=42411 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=33 comm="zsh" exe="/usr/bin/zsh" subj=unconfined key=(null) ARCH=x86_64 SYSCALL=exit_group AUID="root" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"  # noqa
-    """
-    PPID = (9, int)
-    PID = (10, int)
-    AUID = (11, int)
-    UID = (12, int)
-    GID = (13, int)
-    EUID = (14, int)
-    SUID = (15, int)
-    FSUID = (16, int)
-    EGID = (17, int)
-    SGID = (18, int)
-    FSGID = (19, int)
-    TTY = (20, str)
-    SES = (21, int)
-    EXE = (23, str)
-    KEY = (25, str)
-    SYSCALL_STR = (27, str)
-    AUID_STR = (28, str)
-    UID_STR = (29, str)
-    GID_STR = (30, str)
-
-
-class AuditMsgLogin(AuditMsgParser):
-    """
-    Parser for LOGIN type messages
-
-    Sample entry:
-    type=LOGIN msg=audit(1735069956.674:1968): pid=38804 uid=0 subj=unconfined old-auid=4294967295 auid=0 tty=(none) old-ses=4294967295 ses=28 res=1 UID="root" OLD-AUID="unset" AUID="root"  # noqa
-    """
-    OLD_AUID = (5, int)
-    NEW_AUID = (6, int)
-    TTY = (7, str)
-    OLD_SES = (8, int)
-    NEW_SES = (9, int)
-    RES = (10, int)
-
-
-class AuditMsgService(AuditMsgParser):
-    """
-    Parser for SERVICE_START and SERVICE_STOP messages
-
-    Sample entry:
-    "type=SERVICE_START msg=audit(1736973663.599:429): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg='unit=smbd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success' UID=\"root\" AUID=\"unset\""  # noqa
-    """
-    SUBJ = (6, str)
-    UNIT = (7, str)
-    COMM = (8, str)
-    EXE = (9, str)
-    RES = (13, str)
-
-    def get_entry(self, data: list[str]) -> tuple:
-        key, value = super().get_entry(data)
-        match self:
-            case AuditMsgService.UNIT:
-                value = value.split('=', 1)[1]
-                key = 'unit'
-            case AuditMsgService.RES:
-                value = 'success' in value
-            case _:
-                pass
-
-        return (key, value)
-
-
-class AuditMsgPamBase(AuditMsgParser):
-    """
-    Parser for messsages associated with PAM
-
-    Sample entry:
-    type=CRED_DISP msg=audit(1738184696.902:276470): pid=1389074 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg='op=PAM:setcred grantors=pam_rootok acct="truenas_admin" exe="/usr/bin/su" hostname=? addr=? terminal=/dev/pts/0 res=success'
-    """
-    PID = (2, int)
-    FUNCTION = (7, str)
-
-    def get_entry(self, data: list[str]) -> tuple:
-        key, value = super().get_entry(data)
-        if self is AuditMsgPamBase.FUNCTION:
-            value = value.split('=', 1)[1]
-            key = 'function'
-
-        return (key, value)
-
-
-class AuditMsgTty(AuditMsgParser):
-    """
-    pam_tty_audit generates unique multi-part messages.
-
-    Sample entry:
-    type=TTY msg=audit(1737410962.644:698): tty pid=28250 uid=0 auid=0 ses=16 major=136 minor=1 comm="zsh" data=6666667F7F7F7F657869740AUID="root" AUID="root"  # noqa
-    """
-    PID = (3, int)
-    UID = (4, int)
-    SES = (6, int)
-    MAJOR = (7, int)
-    MINOR = (8, int)
-    COMM = (9, str)
-    DATA = (10, str)
-    AUID_STR = (11, str)
-
-    def get_entry(self, data: list[str]) -> tuple:
-        key, value = super().get_entry(data)
-        match self:
-            case AuditMsgTty.DATA:
-                value = value.split('AUID')[0]
-            case AuditMsgTty.AUID_STR:
-                key = 'username'
-
-        return (key, value)
-
-
-class AuditMsgEventType(enum.StrEnum):
-    LOGIN = 'LOGIN'
-    PROCTITLE = 'PROCTITLE'
-    PATH = 'PATH'
-    CWD = 'CWD'
-    EXECVE = 'EXECVE'
-    SYSCALL = 'SYSCALL'
-    CONFIG_CHANGE = 'CONFIG_CHANGE'
-    EOE = 'EOE'
-    BPF = 'BPF'
-    TTY = 'TTY'
-
-
-class AuditEvent(enum.StrEnum):
-    PRIVILEGED = 'privileged'
-    ESCALATION = 'escalation'
-    EXPORT = 'export'
-    IDENTITY = 'identity'
-    TIMECHANGE = 'time-change'
-    MODULE = 'module-load'
-    # Items below are not set as keys
-    GENERIC = 'generic'
-    LOGIN = 'login'
-    SERVICE = 'service'
-    CREDENTIAL = 'credential'
-    TTY_RECORD = 'tty_record'
-
-
-def get_audit_event(parts: list[str]) -> AuditEvent | None:
-    # only syscall events will have the key loaded
-    if get_msg_type(parts) != 'SYSCALL':
-        return None
-
-    # Some syscalls may not have a return value in the audit entry
-    # The simplest way to determine which type of record we have is to
-    # read the beginning the string at the SUCCESS offset.
-    if not parts[AuditMsgSyscall.SUCCESS.idx].startswith('success'):
-        msg_obj = AuditMsgSyscallNoRval
-    else:
-        msg_obj = AuditMsgSyscall
-
-    key, value = msg_obj.KEY.get_entry(parts)
-    if value is None:
-        return AuditEvent.GENERIC
-
-    return AuditEvent(value)
-
-
-@dataclass(slots=True)
-class AUDITEntry:
-    event_type: AuditEvent | None = None
-    key_event: str | None = None
-    raw_lines: list[str] = field(default_factory=list)
-
-
-MULTIPART_EVENT = frozenset([
-    AuditMsgEventType.PROCTITLE,
-    AuditMsgEventType.PATH,
-    AuditMsgEventType.CWD,
-    AuditMsgEventType.EXECVE,
-    AuditMsgEventType.SYSCALL,
-    AuditMsgEventType.CONFIG_CHANGE,
-    AuditMsgEventType.EOE,
-    AuditMsgEventType.BPF,
-    AuditMsgEventType.LOGIN,
-    AuditMsgEventType.TTY,
-])
-
-
-def __parse_cwd(msg_parts: list, event_data: dict) -> None:
-    key, cwd = AuditMsgCwd.CWD.get_entry(msg_parts)
-    event_data['cwd'] = cwd
-
-
-def __parse_path(msg_parts: list, paths: list) -> None:
-    path_entry = {}
-
-    # Use inode field as discriminator. If the 4th element (index 4) starts
-    # with "inode=", this is a full PATH message. Otherwise, it's a PATH
-    # message for a missing/inaccessible file.
-    if len(msg_parts) > 4 and msg_parts[4].startswith('inode='):
-        msg_obj = AuditMsgPath
-    else:
-        msg_obj = AuditMsgMissingPath
-        diag_logger.warn("Watched directory is missing: %r", msg_parts[3])
-
-    # deliberately leave off the item number from the line since it
-    # can be inferred from array index.
-    for item in msg_obj:
-        try:
-            key, value = item.get_entry(msg_parts)
-            path_entry[key] = value
-        except ValueError:
-            diag_logger.exception("unhandled format: %r", ' '.join(msg_parts))
-            path_entry[key] = "-unhandled formatting-"
-
-    paths.append(path_entry)
-
-
-def __parse_proctitle(msg_parts: list, event_data: dict) -> None:
-    key, proctitle = AuditMsgProctitle.PROCTITLE.get_entry(msg_parts)
-    event_data['proctitle'] = proctitle
-
-
-def __parse_syscall(msg_parts: list, event_data: dict) -> None:
-    if event_data.get('syscall') is not None:
-        return
-
-    event_data['syscall'] = {}
-
-    # Some syscalls may not have a return value in the audit entry
-    # The simplest way to determine which type of record we have is to
-    # read the beginning the string at the SUCCESS offset.
-    if not msg_parts[AuditMsgSyscall.SUCCESS.idx].startswith('success'):
-        msg_obj = AuditMsgSyscallNoRval
-    else:
-        msg_obj = AuditMsgSyscall
-
-    for item in msg_obj:
-        key, value = item.get_entry(msg_parts)
-        event_data['syscall'][key] = value
-
-
-def __parse_login(msg_parts: list) -> dict:
-    event_data = {'event_type': AuditEvent.LOGIN.upper()}
-
-    for item in AuditMsgLogin:
-        key, value = item.get_entry(msg_parts)
-        event_data[key] = value
-
-    return event_data
-
-
-def __parse_service(msg_type: str, msg_parts: list) -> dict:
-    event_data = {'event_type': AuditEvent.SERVICE.upper(), 'service_action': msg_type}
-
-    for item in AuditMsgService:
-        key, value = item.get_entry(msg_parts)
-        event_data[key] = value
-
-    return event_data
-
-
-def __parse_tty(msg_parts: list, event_data: dict) -> dict:
-    event_data['event_type'] = AuditEvent.TTY_RECORD.upper()
-    event_data['tty_record'] = {}
-
-    for item in AuditMsgTty:
-        key, value = item.get_entry(msg_parts)
-        event_data['tty_record'][key] = value
-
-    return event_data
-
-
-def __parse_pam(msg_type: str, raw_msg: str, msg_parts: list) -> dict:
-    """Parse audit messages related to PAM.
-    These include message types:
-    'USER_START' | 'USER_END' | 'USER_ACCT' | 'USER_AUTH' | 'USER_LOGIN' | 'USER_ERR' |
-    'CRED_ACQ' | 'CRED_REFR' | 'CRED_DISP'
-
-    Like all auditd messages, PAM messages start with a 'fixed' set of key=value pairs
-    and end with a variable set.
-
-    The delineator between the 'fixed' and 'variable' is a field that starts with `msg='op=`.
-    The processing of that field is handled by AuditMsgPamBase, the 'fixed field'
-    processor for PAM messages.
-
-    The remaining 'variable' fields are processed in this function."""
-
-    event_data = {'event_type': AuditEvent.CREDENTIAL.upper(), 'auth_action': msg_type}
-
-    for item in AuditMsgPamBase:
-        key, value = item.get_entry(msg_parts)
-        event_data[key] = value
-
-    # Extract op_msg from raw string - everything after the function field
-    function_part = msg_parts[AuditMsgPamBase.FUNCTION.idx]
-    function_idx = raw_msg.find(function_part)
-
-    if function_idx == -1:
-        return event_data
-
-    # Extract variable section from raw message
-    op_msg_start = function_idx + len(function_part)
-    op_msg = raw_msg[op_msg_start:].strip()
-
-    # Use regex to split on known field names - preserves spaces within values
-    # Include UID, AUID, ID, GID to capture fields after the closing quote
-    variable_parts = PAM_SPLIT_PATTERN.split(op_msg)
-
-    # Clean up: remove empty strings and strip whitespace
-    variable_parts = [part.strip() for part in variable_parts if part.strip()]
-
-    # Process each key=value pair
-    for item in variable_parts:
-        if '=' not in item:
-            continue
-
-        # Split on first '=' only
-        key, value = item.split('=', 1)
-
-        # Strip quotes if present (both double quotes and single quotes)
-        if value:
-            if value[0] == '"':
-                value = value[1:]
-            if value[-1] == '"':
-                value = value[:-1]
-            # Strip trailing single quote from closing msg quote (e.g., "success'" -> "success")
-            if value[-1] == "'":
-                value = value[:-1]
-
-        # Convert to appropriate type
-        if value.isdigit():
-            value = int(value)
-        elif value in AUDITD_NULL_VALUES:
-            value = None
-
-        # Handle special keys
-        match key:
-            case 'res':
-                value = value.startswith('success')
-            case 'AUID':
-                key = 'username'
-            case 'UID' | 'ID':
-                # We're only concerned about logging the audit uid
-                continue
-            case _:
-                pass
-
-        event_data[key] = value
-
-    return event_data
-
-
-def __parse_raw_msg(msg: str, event_data: dict):
-    # We can include inferred items in our entry
-    parts = msg.split()
-    msg_type = get_msg_type(parts)
-
-    match msg_type:
-        case 'PATH':
-            return __parse_path(parts, event_data['paths'])
-        case 'PROCTITLE':
-            return __parse_proctitle(parts, event_data)
-        case 'CWD':
-            return __parse_cwd(parts, event_data)
-        case 'SYSCALL':
-            return __parse_syscall(parts, event_data)
-        # Below this point are single-part events that return customized
-        # Event data
-        case 'LOGIN':
-            return __parse_login(parts)
-        case 'SERVICE_START' | 'SERVICE_STOP':
-            return __parse_service(msg_type, parts)
-        case 'USER_START' | 'USER_END' | 'USER_ACCT' | 'USER_AUTH' | 'USER_LOGIN' | 'USER_ERR':
-            return __parse_pam(msg_type, msg, parts)
-        case 'CRED_ACQ' | 'CRED_REFR' | 'CRED_DISP':
-            return __parse_pam(msg_type, msg, parts)
-        case 'TTY':
-            return __parse_tty(parts, event_data)
-        case _:
-            pass
-
-
-def __generate_event_data(
-    entry: AUDITEntry,
-    data_out: dict
-) -> None:
-
-    data_out['event'] = data_out['event'].upper()
-    raw_lines = entry.raw_lines
-
-    if entry.key_event:
-        key, user = AuditMsgSyscall.UID_STR.get_entry(entry.key_event)
-        data_out['user'] = user
-
-        key, success = AuditMsgSyscall.SUCCESS.get_entry(entry.key_event)
-        data_out['success'] = success
-        data_out['event_data']['raw_lines'] = None
-
-    for item in raw_lines:
-        if (new_event_data := __parse_raw_msg(item, data_out['event_data'])) is not None:
-            # If event is GENERIC then the entry is defaulted and we can
-            # overwrite safely without losing info
-            if data_out['event'] == AuditEvent.GENERIC.upper():
-                data_out['event_data'] = new_event_data
-                data_out['event'] = data_out['event_data'].pop('event_type')
-
-            # This in principle shouldn't happen but to be on safe side we merge
-            # event data
-            else:
-                new_event_data.pop('event_type')
-                data_out['event_data'] |= new_event_data
-
-            if (username := new_event_data.get('username') or new_event_data.get('acct')) is not None:
-                if not data_out['user']:
-                    data_out['user'] = username
-
-            if (addr := new_event_data.get('addr')) and data_out['addr'] == '127.0.0.1':
-                data_out['addr'] = addr
-
-            if (res := new_event_data.get('res')) is not None:
-                if isinstance(res, bool):
-                    data_out['success'] = res
-
-
-def __parse_msgid(msgid: str, entry_data: dict):
-    """
-    msgid is string such as audit(1734419821.939:3615). The part before the `:`
-    character is a timestamp and the part after it is the audit event id.
-    We need to convert this string into a UUID for the audit event.
-
-    Unfortunately the audit event id is only an unsigned int, and so it's not
-    actually universally unique and potentialy not unique over time.
-
-    We convert this into a UUID by moving the timestamp to upper 64 bits of a
-    128 bit integer, using the audit event id as the bottom 32 bits, and then
-    placing random 32 bits in the middle of it.
-    """
-    msgid = msgid.split('(')[1].strip(')')
-    timestamp, eventid = msgid.split(':')
-    ts_datetime = datetime.fromtimestamp(float(timestamp))
-
-    upper_64 = int(timestamp.replace('.', '')) << 64
-    lower_32 = int(eventid)
-    mid_32 = getrandbits(32) << 32
-
-    entry_data['time'] = ts_datetime.strftime('%Y-%m-%d %H:%M:%S.%f')
-    entry_data['aid'] = str(UUID(int=upper_64 + lower_32 + mid_32))
-
-
-def audit_entry_to_json(msgid: str, entry: AUDITEntry) -> str:
-    to_write = {'TNAUDIT': {
-        'aid': None,
-        'vers': {'major': 0, 'minor': 1},
-        'addr': '127.0.0.1',
-        'user': None,
-        'sess': None,
-        'time': None,
-        'svc': 'SYSTEM',
-        'svc_data': JSON_NULL,  # per our NEP null is OK here
-        'event': entry.event_type or AuditEvent.GENERIC,
-        'event_data': {
-            'audit_msg_id_str': msgid,
-            'proctitle': None,
-            'syscall': None,
-            'cwd': None,
-            'paths': [],
-            'raw_lines': entry.raw_lines
-        },
-        'success': True
-    }}
-
-    __parse_msgid(msgid, to_write['TNAUDIT'])
-    __generate_event_data(entry, to_write['TNAUDIT'])
-
-    to_write['TNAUDIT']['event_data'] = dumps(to_write['TNAUDIT']['event_data'])
-
-    return '@cee:' + dumps(to_write)
 
 
 class DevLogSyslogHandler(logging.handlers.SysLogHandler):
@@ -864,9 +244,9 @@ class AuditdHandler:
         self.diag_queue_listener = None
         self.audis_reader = None
         self.audis_writer = None
-        self.partial_records = defaultdict(AUDITEntry)
         self.pending_queue = deque()
         self.__setup_logger()
+        self.auparse_ctx = truenas_auparse.AuparseContext(callback=self._on_event_ready)
         self.__read_recovery_file()
 
     def __setup_logger(self) -> logging.Logger:
@@ -940,12 +320,30 @@ class AuditdHandler:
             diag_logger.exception("Failed to connect to audispd socket.")
             raise
 
-    async def send_completed(self, msgid: str, data: AUDITEntry) -> None:
-        json_data = audit_entry_to_json(msgid, data)
+    def _on_event_ready(self, event: dict):
+        """Called synchronously from C callback when a complete event is assembled."""
+        msgid = event.get('msgid', '')
+        raw_lines = event.get('raw_lines', [])
+        event_type = classify_event(event)
+
+        key_event_parts = None
+        for record in event.get('records', []):
+            if record.get('type_name') == AuditMsgEventType.SYSCALL:
+                key = record.get('fields', {}).get('key')
+                if key and key not in ('(null)', '(none)', '?', 'unset'):
+                    # Find matching raw line for key_event_parts
+                    for raw_line in raw_lines:
+                        if raw_line.startswith(f'type={AuditMsgEventType.SYSCALL} '):
+                            key_event_parts = raw_line.split()
+                            break
+                break
+
+        json_data = audit_entry_to_json(
+            msgid, event_type, raw_lines, key_event_parts, parsed=event
+        )
         self.logger.critical(json_data)
 
     async def parse_audit_line(self, line: bytes):
-        # decode and strip off trailing newline character
         try:
             decoded = line.decode()[0:-1]
         except Exception:
@@ -957,42 +355,23 @@ class AuditdHandler:
 
         decoded = decoded.replace(AUDITD_LINE_SEPARATOR, ' ')
 
-        parts = decoded.split()
-        msgid = get_msg_id(parts)
-        msgtype = get_msg_type(parts)
-
-        if msgtype not in MULTIPART_EVENT:
-            return (msgid, AUDITEntry(raw_lines=[decoded]))
-
-        # Keep adding to raw_lines until we get an End of Event (EOE) message.
-        entry = self.partial_records[msgid]
-        entry.raw_lines.append(decoded)
-
-        # prioritize line with the identifier key
-        if (audit_event := get_audit_event(parts)) is not None:
-            entry.event_type = audit_event
-            entry.key_event = parts
-
-        if msgtype != AuditMsgEventType.EOE:
-            # Incomplete message. We store in `partial_records` dictionary
-            # until it is completed.
-            return None
-
-        return (msgid, self.partial_records.pop(msgid))
+        try:
+            self.auparse_ctx.feed(decoded)
+        except Exception:
+            diag_logger.exception("Failed to feed line to auparse context.")
 
     async def handle_auditd_msg(self):
         # Auditd messages are newline-terminated
         data = await self.audis_reader.readline()
-        if (completed := await self.parse_audit_line(data)) is not None:
-            await self.send_completed(*completed)
+        await self.parse_audit_line(data)
 
-            # Monitor pending queue depth and warn if getting high
-            # TODO: Add alert messages
-            queue_depth = len(self.pending_queue)
-            if queue_depth >= ALERT_QUEUE_DEPTH:
-                diag_logger.critical("Pending queue depth critical: %d messages queued", queue_depth)
-            elif queue_depth >= ALERT_QUEUE_DEPTH * 0.75:
-                diag_logger.warning("Pending queue depth high: %d messages queued", queue_depth)
+        # Monitor pending queue depth and warn if getting high
+        # TODO: Add alert messages
+        queue_depth = len(self.pending_queue)
+        if queue_depth >= ALERT_QUEUE_DEPTH:
+            diag_logger.critical("Pending queue depth critical: %d messages queued", queue_depth)
+        elif queue_depth >= ALERT_QUEUE_DEPTH * 0.75:
+            diag_logger.warning("Pending queue depth high: %d messages queued", queue_depth)
 
     def __setup_signal_handlers(self):
         self.loop.add_signal_handler(signal.SIGTERM, self.terminate)
@@ -1016,6 +395,56 @@ class AuditdHandler:
         # a good state. Write out the recovery file and hope for happier
         # times after a service restart.
         await self.loop.run_in_executor(None, self.__write_recovery_file)
+
+
+def _is_enterprise() -> bool | None:
+    """Single attempt to check enterprise status. Returns None on any error."""
+    try:
+        with Client() as c:
+            return c.call('system.is_enterprise')
+    except Exception:
+        return None
+
+
+def _wait_for_enterprise_on_startup() -> bool:
+    """
+    Retries enterprise check until middlewared responds or timeout expires.
+    Returns True (enterprise), False (CE), defaults to False on timeout.
+    """
+    deadline = time.monotonic() + ENTERPRISE_CHECK_TIMEOUT
+    while time.monotonic() < deadline:
+        result = _is_enterprise()
+        if result is not None:
+            diag_logger.info("Enterprise check: is_enterprise=%r", result)
+            return result
+        diag_logger.debug(
+            "Middlewared not yet available, retrying in %ds", ENTERPRISE_CHECK_INTERVAL
+        )
+        time.sleep(ENTERPRISE_CHECK_INTERVAL)
+
+    diag_logger.warning(
+        "Could not reach middlewared within %ds. Defaulting to CE (no-op).",
+        ENTERPRISE_CHECK_TIMEOUT
+    )
+    return False
+
+
+def _ce_noop_loop() -> None:
+    """
+    Block indefinitely on CE systems. Polls for a license periodically so
+    that if one is installed the handler activates without a manual restart.
+    Returns when system.is_enterprise becomes True.
+    """
+    diag_logger.info(
+        "Community Edition — kernel audit handler disabled. "
+        "Polling every %ds for enterprise license.", ENTERPRISE_RECHECK_INTERVAL
+    )
+    while True:
+        time.sleep(ENTERPRISE_RECHECK_INTERVAL)
+        result = _is_enterprise()
+        if result is True:
+            diag_logger.info("Enterprise license detected. Starting audit handler.")
+            return
 
 
 def __process_args() -> argparse.Namespace:
@@ -1056,6 +485,10 @@ def main():
 
     # Set up module-level diagnostic logger before creating handler
     setup_diagnostic_logger()
+
+    if not _wait_for_enterprise_on_startup():
+        _ce_noop_loop()
+        # Falls through here only when a license is installed mid-run
 
     loop = asyncio.new_event_loop()
     handler = AuditdHandler(

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+from setuptools import setup, Extension
+
+truenas_auparse_ext = Extension(
+    'truenas_auparse',
+    sources=[
+        'src/cext/truenas_auparse.c',
+        'src/cext/auparse_event.c',
+        'src/cext/auparse_feed.c',
+    ],
+    include_dirs=['src/cext'],
+    libraries=['auparse', 'audit'],
+)
+
+setup(
+    ext_modules=[truenas_auparse_ext],
+    packages=['truenas_auparse', '_truenas_audit_scripts', 'truenas_audit_parse'],
+    package_dir={
+        'truenas_auparse': 'stubs',
+        '_truenas_audit_scripts': 'scripts',
+        'truenas_audit_parse': 'src/truenas_audit_parse',
+    },
+    package_data={
+        'truenas_auparse': ['*.pyi', 'py.typed'],
+        'truenas_audit_parse': ['py.typed'],
+    },
+)

--- a/src/cext/auparse_event.c
+++ b/src/cext/auparse_event.c
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) TrueNAS, 2026
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "common/includes.h"
+#include "auparse_event.h"
+#include <auparse.h>
+#include <libaudit.h>
+
+/*
+ * Parse a single record's fields into a Python dict.
+ * Caller must hold the GIL. auparse cursor must be positioned on the record.
+ *
+ * Returns a new reference to a dict: {"type": str, "type_name": str, "fields": {name: value, ...}}
+ * Returns NULL with exception set on error.
+ */
+PyObject *
+parse_record_fields(auparse_state_t *au)
+{
+	PyObject *record_dict = NULL;
+	PyObject *fields_dict = NULL;
+	PyObject *raw_fields_dict = NULL;
+	PyObject *key = NULL;
+	PyObject *val = NULL;
+	PyObject *raw_val = NULL;
+	const char *type_name;
+	int record_type;
+
+	record_dict = PyDict_New();
+	if (record_dict == NULL)
+		return NULL;
+
+	fields_dict = PyDict_New();
+	if (fields_dict == NULL)
+		goto error;
+
+	raw_fields_dict = PyDict_New();
+	if (raw_fields_dict == NULL)
+		goto error;
+
+	record_type = auparse_get_type(au);
+	type_name = auparse_get_type_name(au);
+
+	/* Set record type as integer */
+	val = PyLong_FromLong(record_type);
+	if (val == NULL)
+		goto error;
+	if (PyDict_SetItemString(record_dict, "type", val) < 0)
+		goto error;
+	Py_CLEAR(val);
+
+	/* Set record type name */
+	if (type_name != NULL) {
+		val = PyUnicode_FromString(type_name);
+	} else {
+		val = PyUnicode_FromFormat("UNKNOWN[%d]", record_type);
+	}
+	if (val == NULL)
+		goto error;
+	if (PyDict_SetItemString(record_dict, "type_name", val) < 0)
+		goto error;
+	Py_CLEAR(val);
+
+	/* Iterate fields */
+	if (auparse_first_field(au) < 1) {
+		/* No fields - just return the dict with empty fields */
+		if (PyDict_SetItemString(record_dict, "fields", fields_dict) < 0)
+			goto error;
+		if (PyDict_SetItemString(record_dict, "raw_fields", raw_fields_dict) < 0)
+			goto error;
+		Py_DECREF(fields_dict);
+		Py_DECREF(raw_fields_dict);
+		return record_dict;
+	}
+
+	do {
+		const char *field_name = auparse_get_field_name(au);
+		const char *field_value = auparse_interpret_field(au);
+		const char *raw_field_value = auparse_get_field_str(au);
+		size_t fv_len;
+
+		if (field_name == NULL || field_value == NULL)
+			continue;
+
+		key = PyUnicode_FromString(field_name);
+		if (key == NULL)
+			goto error;
+
+		/*
+		 * auparse_interpret_field() with AUPARSE_ESC_RAW returns
+		 * quoted strings for resolved UID-type fields (e.g.
+		 * "sharinguser" instead of sharinguser). Strip the outer
+		 * double-quotes so consumers get bare values matching the
+		 * old hand-rolled parser's behaviour.
+		 */
+		fv_len = strlen(field_value);
+		if (fv_len >= 2 &&
+		    field_value[0] == '"' &&
+		    field_value[fv_len - 1] == '"') {
+			val = PyUnicode_FromStringAndSize(
+				field_value + 1, fv_len - 2);
+		} else {
+			val = PyUnicode_FromString(field_value);
+		}
+		if (val == NULL)
+			goto error;
+
+		if (PyDict_SetItem(fields_dict, key, val) < 0)
+			goto error;
+		Py_CLEAR(val);
+
+		/* Store raw (uninterpreted) field value */
+		if (raw_field_value != NULL) {
+			raw_val = PyUnicode_FromString(raw_field_value);
+			if (raw_val == NULL)
+				goto error;
+			if (PyDict_SetItem(raw_fields_dict, key, raw_val) < 0)
+				goto error;
+			Py_CLEAR(raw_val);
+		}
+
+		Py_CLEAR(key);
+	} while (auparse_next_field(au) > 0);
+
+	if (PyDict_SetItemString(record_dict, "fields", fields_dict) < 0)
+		goto error;
+	if (PyDict_SetItemString(record_dict, "raw_fields", raw_fields_dict) < 0)
+		goto error;
+
+	Py_DECREF(fields_dict);
+	Py_DECREF(raw_fields_dict);
+	return record_dict;
+
+error:
+	Py_XDECREF(record_dict);
+	Py_XDECREF(fields_dict);
+	Py_XDECREF(raw_fields_dict);
+	Py_XDECREF(key);
+	Py_XDECREF(val);
+	Py_XDECREF(raw_val);
+	return NULL;
+}
+
+
+/*
+ * Build event dict from an already-initialized auparse_state_t.
+ * Iterates all records and returns {"records": [...]}.
+ * Returns NULL with exception set on error.
+ */
+PyObject *
+build_event_dict(auparse_state_t *au)
+{
+	PyObject *result = NULL;
+	PyObject *records_list = NULL;
+	PyObject *record = NULL;
+
+	result = PyDict_New();
+	if (result == NULL)
+		return NULL;
+
+	records_list = PyList_New(0);
+	if (records_list == NULL)
+		goto cleanup;
+
+	/* Position on first record */
+	if (auparse_first_record(au) < 1) {
+		/* No records found - return empty list */
+		if (PyDict_SetItemString(result, "records", records_list) < 0)
+			goto cleanup;
+		Py_DECREF(records_list);
+		return result;
+	}
+
+	do {
+		record = parse_record_fields(au);
+		if (record == NULL)
+			goto cleanup;
+
+		if (PyList_Append(records_list, record) < 0) {
+			Py_DECREF(record);
+			goto cleanup;
+		}
+		Py_DECREF(record);
+		record = NULL;
+	} while (auparse_next_record(au) > 0);
+
+	if (PyDict_SetItemString(result, "records", records_list) < 0)
+		goto cleanup;
+
+	Py_DECREF(records_list);
+	return result;
+
+cleanup:
+	Py_XDECREF(result);
+	Py_XDECREF(records_list);
+	return NULL;
+}
+
+
+/*
+ * parse_event(raw_text) -> dict
+ *
+ * Parse one or more audit records (newline-separated) using libauparse.
+ *
+ * Returns: {"records": [{"type": int, "type_name": str, "fields": {name: value}}, ...]}
+ */
+PyObject *
+do_parse_event(const char *raw_text)
+{
+	auparse_state_t *au = NULL;
+	PyObject *result = NULL;
+	char *buf = NULL;
+	size_t len;
+
+	/*
+	 * auparse_init(AUSOURCE_BUFFER) requires newline-terminated input.
+	 * Ensure the buffer ends with a newline.
+	 */
+	len = strlen(raw_text);
+	if (len == 0 || raw_text[len - 1] != '\n') {
+		buf = PyMem_RawMalloc(len + 2);
+		if (buf == NULL) {
+			PyErr_NoMemory();
+			return NULL;
+		}
+		memcpy(buf, raw_text, len);
+		buf[len] = '\n';
+		buf[len + 1] = '\0';
+		raw_text = buf;
+	}
+
+	/* Initialize auparse from buffer - this does the heavy parsing */
+	Py_BEGIN_ALLOW_THREADS
+	au = auparse_init(AUSOURCE_BUFFER, raw_text);
+	Py_END_ALLOW_THREADS
+
+	if (au == NULL) {
+		PyErr_SetString(PyExc_RuntimeError,
+				"auparse_init failed");
+		PyMem_RawFree(buf);
+		return NULL;
+	}
+
+	/* Use RAW escape mode to avoid mangling */
+	auparse_set_escape_mode(au, AUPARSE_ESC_RAW);
+
+	result = build_event_dict(au);
+
+	Py_BEGIN_ALLOW_THREADS
+	auparse_destroy(au);
+	Py_END_ALLOW_THREADS
+	PyMem_RawFree(buf);
+	return result;
+}
+
+
+/*
+ * get_record_type(raw_text) -> str
+ *
+ * Lightweight extraction of just the record type from the first record.
+ */
+PyObject *
+do_get_record_type(const char *raw_text)
+{
+	auparse_state_t *au = NULL;
+	PyObject *result = NULL;
+	const char *type_name;
+	char *buf = NULL;
+	size_t len;
+	const char *original_raw = raw_text;
+
+	/* Ensure newline-terminated input for auparse */
+	len = strlen(raw_text);
+	if (len == 0 || raw_text[len - 1] != '\n') {
+		buf = PyMem_RawMalloc(len + 2);
+		if (buf == NULL) {
+			PyErr_NoMemory();
+			return NULL;
+		}
+		memcpy(buf, raw_text, len);
+		buf[len] = '\n';
+		buf[len + 1] = '\0';
+		raw_text = buf;
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	au = auparse_init(AUSOURCE_BUFFER, raw_text);
+	Py_END_ALLOW_THREADS
+
+	if (au == NULL) {
+		PyErr_SetString(PyExc_RuntimeError,
+				"auparse_init failed");
+		PyMem_RawFree(buf);
+		return NULL;
+	}
+
+	if (auparse_first_record(au) < 1) {
+		/* Fallback for records like EOE with no parseable fields */
+		if (strncmp(original_raw, "type=", 5) == 0) {
+			const char *start = original_raw + 5;
+			const char *end = strchr(start, ' ');
+			if (end != NULL) {
+				result = PyUnicode_FromStringAndSize(start, end - start);
+				goto cleanup;
+			}
+		}
+		PyErr_SetString(PyExc_ValueError,
+				"No records found in input");
+		goto cleanup;
+	}
+
+	type_name = auparse_get_type_name(au);
+	if (type_name != NULL) {
+		result = PyUnicode_FromString(type_name);
+	} else {
+		result = PyUnicode_FromFormat("UNKNOWN[%d]",
+					     auparse_get_type(au));
+	}
+
+cleanup:
+	Py_BEGIN_ALLOW_THREADS
+	auparse_destroy(au);
+	Py_END_ALLOW_THREADS
+	PyMem_RawFree(buf);
+	return result;
+}

--- a/src/cext/auparse_event.h
+++ b/src/cext/auparse_event.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) TrueNAS, 2026
+
+#ifndef _AUPARSE_EVENT_H_
+#define _AUPARSE_EVENT_H_
+
+#include <Python.h>
+#include <auparse.h>
+
+PyObject *do_parse_event(const char *raw_text);
+PyObject *do_get_record_type(const char *raw_text);
+PyObject *parse_record_fields(auparse_state_t *au);
+PyObject *build_event_dict(auparse_state_t *au);
+
+#endif /* _AUPARSE_EVENT_H_ */

--- a/src/cext/auparse_feed.c
+++ b/src/cext/auparse_feed.c
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) TrueNAS, 2026
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "common/includes.h"
+#include "auparse_feed.h"
+#include "auparse_event.h"
+#include <auparse.h>
+#include <libaudit.h>
+
+typedef struct {
+	PyObject_HEAD
+	auparse_state_t *au;
+	PyObject *py_callback;
+} AuparseContextObject;
+
+/*
+ * Extract msgid from raw audit text.
+ * Looks for "msg=audit(TIMESTAMP:ID)" pattern and returns
+ * "audit(TIMESTAMP:ID)" as a Python string, or None if not found.
+ */
+static PyObject *
+extract_msgid(const char *raw_text)
+{
+	const char *start, *end;
+
+	start = strstr(raw_text, "msg=audit(");
+	if (start == NULL)
+		Py_RETURN_NONE;
+
+	start += 4; /* skip "msg=" to get "audit(..." */
+	end = strchr(start, ')');
+	if (end == NULL)
+		Py_RETURN_NONE;
+
+	return PyUnicode_FromStringAndSize(start, end - start + 1);
+}
+
+
+/*
+ * C callback invoked by auparse_feed() when an event is ready.
+ * GIL is held because auparse_feed() is called from Python.
+ */
+static void
+auparse_cb(auparse_state_t *au, auparse_cb_event_t cb_event_type,
+           void *user_data)
+{
+	AuparseContextObject *self = (AuparseContextObject *)user_data;
+	PyObject *event_dict = NULL;
+	PyObject *records_list = NULL;
+	PyObject *raw_lines_list = NULL;
+	PyObject *record = NULL;
+	PyObject *raw_line = NULL;
+	PyObject *msgid = NULL;
+	PyObject *call_result = NULL;
+	const char *record_text;
+
+	if (cb_event_type != AUPARSE_CB_EVENT_READY)
+		return;
+
+	/* If a previous callback already raised, do not process more events */
+	if (PyErr_Occurred())
+		return;
+
+	event_dict = PyDict_New();
+	if (event_dict == NULL)
+		return;
+
+	records_list = PyList_New(0);
+	if (records_list == NULL)
+		goto error;
+
+	raw_lines_list = PyList_New(0);
+	if (raw_lines_list == NULL)
+		goto error;
+
+	/* Iterate all records in this event */
+	if (auparse_first_record(au) < 1)
+		goto done;
+
+	/* Extract msgid from the first record's raw text */
+	record_text = auparse_get_record_text(au);
+	if (record_text != NULL) {
+		msgid = extract_msgid(record_text);
+	} else {
+		msgid = Py_None;
+		Py_INCREF(msgid);
+	}
+	if (msgid == NULL)
+		goto error;
+
+	do {
+		record = parse_record_fields(au);
+		if (record == NULL)
+			goto error;
+
+		if (PyList_Append(records_list, record) < 0) {
+			Py_DECREF(record);
+			goto error;
+		}
+		Py_DECREF(record);
+		record = NULL;
+
+		/* Capture raw line text */
+		record_text = auparse_get_record_text(au);
+		if (record_text != NULL) {
+			raw_line = PyUnicode_FromString(record_text);
+		} else {
+			raw_line = PyUnicode_FromString("");
+		}
+		if (raw_line == NULL)
+			goto error;
+
+		if (PyList_Append(raw_lines_list, raw_line) < 0) {
+			Py_DECREF(raw_line);
+			goto error;
+		}
+		Py_DECREF(raw_line);
+		raw_line = NULL;
+	} while (auparse_next_record(au) > 0);
+
+done:
+	if (PyDict_SetItemString(event_dict, "records", records_list) < 0)
+		goto error;
+	if (PyDict_SetItemString(event_dict, "raw_lines", raw_lines_list) < 0)
+		goto error;
+
+	if (msgid == NULL) {
+		msgid = Py_None;
+		Py_INCREF(msgid);
+	}
+	if (PyDict_SetItemString(event_dict, "msgid", msgid) < 0)
+		goto error;
+
+	/* Invoke the Python callback */
+	call_result = PyObject_CallOneArg(self->py_callback, event_dict);
+	if (call_result == NULL) {
+		/* Exception set by the callback - will be checked after feed() returns */
+		goto error;
+	}
+	Py_DECREF(call_result);
+
+	Py_DECREF(event_dict);
+	Py_DECREF(records_list);
+	Py_DECREF(raw_lines_list);
+	Py_DECREF(msgid);
+	return;
+
+error:
+	Py_XDECREF(event_dict);
+	Py_XDECREF(records_list);
+	Py_XDECREF(raw_lines_list);
+	Py_XDECREF(msgid);
+	return;
+}
+
+
+static int
+AuparseContext_traverse(AuparseContextObject *self, visitproc visit, void *arg)
+{
+	Py_VISIT(self->py_callback);
+	return 0;
+}
+
+static int
+AuparseContext_clear(AuparseContextObject *self)
+{
+	Py_CLEAR(self->py_callback);
+	return 0;
+}
+
+
+static int
+AuparseContext_init(AuparseContextObject *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {"callback", NULL};
+	PyObject *callback = NULL;
+
+	/* Bug 2 fix: reinitialisation — clean up previous state first */
+	if (self->au != NULL) {
+		auparse_destroy(self->au);
+		self->au = NULL;
+	}
+	Py_CLEAR(self->py_callback);
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &callback))
+		return -1;
+
+	if (!PyCallable_Check(callback)) {
+		PyErr_SetString(PyExc_TypeError,
+				"callback must be callable");
+		return -1;
+	}
+
+	Py_INCREF(callback);
+	self->py_callback = callback;
+
+	self->au = auparse_init(AUSOURCE_FEED, NULL);
+	if (self->au == NULL) {
+		PyErr_SetString(PyExc_RuntimeError,
+				"auparse_init(AUSOURCE_FEED) failed");
+		Py_DECREF(callback);
+		self->py_callback = NULL;
+		return -1;
+	}
+
+	auparse_set_escape_mode(self->au, AUPARSE_ESC_RAW);
+	auparse_add_callback(self->au, auparse_cb, self, NULL);
+
+	return 0;
+}
+
+
+static void
+AuparseContext_dealloc(AuparseContextObject *self)
+{
+	PyObject_GC_UnTrack(self);
+	if (self->au != NULL) {
+		auparse_destroy(self->au);
+		self->au = NULL;
+	}
+	Py_XDECREF(self->py_callback);
+	self->py_callback = NULL;
+	Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+
+PyDoc_STRVAR(feed__doc__,
+"feed(line)\n"
+"--\n\n"
+"Feed a line of audit text to the parser.\n\n"
+"The callback is invoked synchronously when a complete event is assembled.\n"
+);
+
+static PyObject *
+AuparseContext_feed(AuparseContextObject *self, PyObject *args)
+{
+	const char *line;
+	Py_ssize_t line_len;
+	char *buf = NULL;
+
+	if (!PyArg_ParseTuple(args, "s#", &line, &line_len))
+		return NULL;
+
+	/* Ensure newline-terminated for auparse_feed */
+	if (line_len == 0 || line[line_len - 1] != '\n') {
+		buf = PyMem_RawMalloc(line_len + 2);
+		if (buf == NULL)
+			return PyErr_NoMemory();
+		memcpy(buf, line, line_len);
+		buf[line_len] = '\n';
+		buf[line_len + 1] = '\0';
+		auparse_feed(self->au, buf, line_len + 1);
+		PyMem_RawFree(buf);
+	} else {
+		auparse_feed(self->au, line, line_len);
+	}
+
+	/* Check if the callback raised an exception */
+	if (PyErr_Occurred())
+		return NULL;
+
+	Py_RETURN_NONE;
+}
+
+
+PyDoc_STRVAR(flush__doc__,
+"flush()\n"
+"--\n\n"
+"Flush the feed parser, triggering callbacks for any incomplete events.\n"
+);
+
+static PyObject *
+AuparseContext_flush(AuparseContextObject *self, PyObject *Py_UNUSED(args))
+{
+	auparse_flush_feed(self->au);
+
+	if (PyErr_Occurred())
+		return NULL;
+
+	Py_RETURN_NONE;
+}
+
+
+static PyMethodDef AuparseContext_methods[] = {
+	{
+		.ml_name = "feed",
+		.ml_meth = (PyCFunction)AuparseContext_feed,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = feed__doc__,
+	},
+	{
+		.ml_name = "flush",
+		.ml_meth = (PyCFunction)AuparseContext_flush,
+		.ml_flags = METH_NOARGS,
+		.ml_doc = flush__doc__,
+	},
+	{ NULL, NULL, 0, NULL }
+};
+
+
+PyTypeObject AuparseContextType = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	.tp_name = "truenas_auparse.AuparseContext",
+	.tp_basicsize = sizeof(AuparseContextObject),
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_doc = "Streaming audit event parser using libauparse feed+callback model.\n"
+	           "Accepts a Python callable that is invoked when complete events are assembled.",
+	.tp_new = PyType_GenericNew,
+	.tp_init = (initproc)AuparseContext_init,
+	.tp_dealloc = (destructor)AuparseContext_dealloc,
+	.tp_traverse = (traverseproc)AuparseContext_traverse,
+	.tp_clear = (inquiry)AuparseContext_clear,
+	.tp_methods = AuparseContext_methods,
+};

--- a/src/cext/auparse_feed.h
+++ b/src/cext/auparse_feed.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) TrueNAS, 2026
+
+#ifndef _AUPARSE_FEED_H_
+#define _AUPARSE_FEED_H_
+
+#include <Python.h>
+
+extern PyTypeObject AuparseContextType;
+
+#endif /* _AUPARSE_FEED_H_ */

--- a/src/cext/common/includes.h
+++ b/src/cext/common/includes.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) TrueNAS, 2026
+
+#ifndef _INCLUDES_H_
+#define _INCLUDES_H_
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
+#define __STRING(x) #x
+#define __STRINGSTRING(x) __STRING(x)
+#define __LINESTR__ __STRINGSTRING(__LINE__)
+#define __location__ __FILE__ ":" __LINESTR__
+#endif /* _INCLUDES_H_ */

--- a/src/cext/truenas_auparse.c
+++ b/src/cext/truenas_auparse.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) TrueNAS, 2026
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "common/includes.h"
+#include "auparse_event.h"
+#include "auparse_feed.h"
+
+#define MODULE_DOC "TrueNAS audit event parsing via libauparse"
+
+PyDoc_STRVAR(py_parse_event__doc__,
+"parse_event(raw_text)\n"
+"--\n\n"
+"Parse audit event text using libauparse.\n\n"
+"Takes one or more newline-separated audit records and returns\n"
+"a dict with interpreted field values.\n\n"
+"Parameters\n"
+"----------\n"
+"raw_text : str\n"
+"    Raw audit event text (one or more records, newline-separated)\n\n"
+"Returns\n"
+"-------\n"
+"dict\n"
+"    {'records': [{'type': int, 'type_name': str, 'fields': {name: value, ...}}, ...]}\n"
+);
+
+static PyObject *
+py_parse_event(PyObject *self, PyObject *args)
+{
+	const char *raw_text;
+
+	if (!PyArg_ParseTuple(args, "s", &raw_text))
+		return NULL;
+
+	return do_parse_event(raw_text);
+}
+
+PyDoc_STRVAR(py_get_record_type__doc__,
+"get_record_type(raw_text)\n"
+"--\n\n"
+"Get the record type name from the first record in raw audit text.\n\n"
+"Parameters\n"
+"----------\n"
+"raw_text : str\n"
+"    Raw audit record text\n\n"
+"Returns\n"
+"-------\n"
+"str\n"
+"    Record type name (e.g., 'SYSCALL', 'PATH', 'LOGIN')\n"
+);
+
+static PyObject *
+py_get_record_type(PyObject *self, PyObject *args)
+{
+	const char *raw_text;
+
+	if (!PyArg_ParseTuple(args, "s", &raw_text))
+		return NULL;
+
+	return do_get_record_type(raw_text);
+}
+
+static PyMethodDef truenas_auparse_methods[] = {
+	{
+		.ml_name = "parse_event",
+		.ml_meth = (PyCFunction)py_parse_event,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = py_parse_event__doc__,
+	},
+	{
+		.ml_name = "get_record_type",
+		.ml_meth = (PyCFunction)py_get_record_type,
+		.ml_flags = METH_VARARGS,
+		.ml_doc = py_get_record_type__doc__,
+	},
+	{ NULL, NULL, 0, NULL }
+};
+
+static struct PyModuleDef truenas_auparse_module = {
+	PyModuleDef_HEAD_INIT,
+	.m_name = "truenas_auparse",
+	.m_doc = MODULE_DOC,
+	.m_size = -1,
+	.m_methods = truenas_auparse_methods,
+};
+
+PyMODINIT_FUNC
+PyInit_truenas_auparse(void)
+{
+	PyObject *m;
+
+	if (PyType_Ready(&AuparseContextType) < 0)
+		return NULL;
+
+	m = PyModule_Create(&truenas_auparse_module);
+	if (m == NULL)
+		return NULL;
+
+	Py_INCREF(&AuparseContextType);
+	if (PyModule_AddObject(m, "AuparseContext",
+			       (PyObject *)&AuparseContextType) < 0) {
+		Py_DECREF(&AuparseContextType);
+		Py_DECREF(m);
+		return NULL;
+	}
+
+	return m;
+}

--- a/src/truenas_audit_parse/__init__.py
+++ b/src/truenas_audit_parse/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+from .event_types import AuditEvent, AuditMsgEventType
+from .parsers import parse_multipart_event, classify_event
+from .formatter import audit_entry_to_json
+from .constants import MULTIPART_EVENT_TYPES
+
+__all__ = [
+    'AuditEvent',
+    'AuditMsgEventType',
+    'parse_multipart_event',
+    'classify_event',
+    'audit_entry_to_json',
+    'MULTIPART_EVENT_TYPES',
+]

--- a/src/truenas_audit_parse/constants.py
+++ b/src/truenas_audit_parse/constants.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+import re
+
+from .event_types import AuditMsgEventType
+
+AUDITD_LINE_SEPARATOR = '\x1d'
+AUDITD_NULL_VALUES = frozenset(['(null)', '(none)', '?', 'unset'])
+JSON_NULL = 'null'
+MULTIPART_EVENT_TYPES = frozenset([
+    AuditMsgEventType.PROCTITLE, AuditMsgEventType.PATH,
+    AuditMsgEventType.CWD, AuditMsgEventType.EXECVE,
+    AuditMsgEventType.SYSCALL, AuditMsgEventType.CONFIG_CHANGE,
+    AuditMsgEventType.EOE, AuditMsgEventType.BPF,
+    AuditMsgEventType.LOGIN, AuditMsgEventType.TTY,
+])
+PAM_MSG_TYPES = frozenset([
+    AuditMsgEventType.USER_START, AuditMsgEventType.USER_END,
+    AuditMsgEventType.USER_ACCT, AuditMsgEventType.USER_AUTH,
+    AuditMsgEventType.USER_LOGIN, AuditMsgEventType.USER_ERR,
+    AuditMsgEventType.CRED_ACQ, AuditMsgEventType.CRED_REFR,
+    AuditMsgEventType.CRED_DISP,
+])
+SERVICE_MSG_TYPES = frozenset([
+    AuditMsgEventType.SERVICE_START, AuditMsgEventType.SERVICE_STOP,
+])
+PAM_SPLIT_PATTERN = re.compile(
+    r'(?=\b(?:grantors|acct|exe|hostname|addr|terminal|res|UID|AUID|ID|GID)=)'
+)

--- a/src/truenas_audit_parse/event_types.py
+++ b/src/truenas_audit_parse/event_types.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+import enum
+
+
+class AuditMsgEventType(enum.StrEnum):
+    LOGIN = 'LOGIN'
+    PROCTITLE = 'PROCTITLE'
+    PATH = 'PATH'
+    CWD = 'CWD'
+    EXECVE = 'EXECVE'
+    SYSCALL = 'SYSCALL'
+    CONFIG_CHANGE = 'CONFIG_CHANGE'
+    EOE = 'EOE'
+    BPF = 'BPF'
+    TTY = 'TTY'
+    # PAM / credential record types
+    USER_START = 'USER_START'
+    USER_END = 'USER_END'
+    USER_ACCT = 'USER_ACCT'
+    USER_AUTH = 'USER_AUTH'
+    USER_LOGIN = 'USER_LOGIN'
+    USER_ERR = 'USER_ERR'
+    CRED_ACQ = 'CRED_ACQ'
+    CRED_REFR = 'CRED_REFR'
+    CRED_DISP = 'CRED_DISP'
+    # Service record types
+    SERVICE_START = 'SERVICE_START'
+    SERVICE_STOP = 'SERVICE_STOP'
+
+
+class AuditEvent(enum.StrEnum):
+    PRIVILEGED = 'privileged'
+    ESCALATION = 'escalation'
+    EXPORT = 'export'
+    IDENTITY = 'identity'
+    TIMECHANGE = 'time-change'
+    MODULE = 'module-load'
+    # Items below are not set as keys
+    GENERIC = 'generic'
+    LOGIN = 'login'
+    SERVICE = 'service'
+    CREDENTIAL = 'credential'
+    TTY_RECORD = 'tty_record'

--- a/src/truenas_audit_parse/formatter.py
+++ b/src/truenas_audit_parse/formatter.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+from datetime import datetime
+from json import dumps
+from random import getrandbits
+from uuid import UUID
+
+from .constants import AUDITD_NULL_VALUES, JSON_NULL
+from .event_types import AuditEvent, AuditMsgEventType
+from .parsers import (
+    classify_event,
+    parse_multipart_event,
+    RECORD_PROCESSORS,
+)
+
+
+def parse_msgid(msgid: str) -> tuple[str, str]:
+    """Parse audit message ID into a UUID and timestamp string.
+
+    msgid is a string such as 'audit(1734419821.939:3615)'. The part before
+    the ':' is a timestamp and the part after is the audit event id.
+
+    We convert this into a UUID by placing the timestamp in the upper 64 bits,
+    random 32 bits in the middle, and the event id in the lower 32 bits.
+
+    Returns:
+        (aid, time_str) tuple
+    """
+    inner = msgid.split('(')[1].strip(')')
+    timestamp, eventid = inner.split(':')
+    ts_datetime = datetime.fromtimestamp(float(timestamp))
+
+    upper_64 = int(timestamp.replace('.', '')) << 64
+    lower_32 = int(eventid)
+    mid_32 = getrandbits(32) << 32
+
+    time_str = ts_datetime.strftime('%Y-%m-%d %H:%M:%S.%f')
+    aid = str(UUID(int=upper_64 + lower_32 + mid_32))
+
+    return (aid, time_str)
+
+
+def _generate_event_data(
+    parsed: dict,
+    event_type: AuditEvent,
+    raw_lines: list[str],
+    key_event_parts: list[str] | None,
+) -> dict:
+    """Build TNAUDIT event_data dict from parsed records.
+
+    Every event arrives fully assembled (auparse groups all records by msgid).
+    We iterate the records, apply processors, and build the output dict.
+    """
+    event_data = {}
+    user = None
+    success = True
+    addr = '127.0.0.1'
+    event = event_type or AuditEvent.GENERIC
+
+    for record in parsed.get('records', []):
+        type_name = record.get('type_name', '')
+        fields = record.get('fields', {})
+        raw_fields = record.get('raw_fields', {})
+
+        processor = RECORD_PROCESSORS.get(type_name)
+        if processor is not None:
+            fields = processor(fields, raw_fields)
+
+        match type_name:
+            case AuditMsgEventType.SYSCALL:
+                if 'syscall' not in event_data:
+                    event_data['syscall'] = fields
+                    uid_str = fields.get('UID')
+                    if uid_str and uid_str not in AUDITD_NULL_VALUES:
+                        user = uid_str
+                    if 'success' in fields:
+                        success = fields['success']
+
+            case AuditMsgEventType.PATH:
+                event_data.setdefault('paths', []).append(fields)
+
+            case AuditMsgEventType.PROCTITLE:
+                event_data['proctitle'] = fields.get('proctitle')
+
+            case AuditMsgEventType.CWD:
+                event_data['cwd'] = fields.get('cwd')
+
+            case AuditMsgEventType.LOGIN:
+                event_data.update(fields)
+                event = AuditEvent.LOGIN
+
+            case AuditMsgEventType.SERVICE_START | AuditMsgEventType.SERVICE_STOP:
+                event_data['service_action'] = type_name
+                event_data.update(fields)
+                event = AuditEvent.SERVICE
+                if 'res' in fields and isinstance(fields['res'], bool):
+                    success = fields['res']
+
+            case AuditMsgEventType.USER_START | AuditMsgEventType.USER_END | \
+                 AuditMsgEventType.USER_ACCT | AuditMsgEventType.USER_AUTH | \
+                 AuditMsgEventType.USER_LOGIN | AuditMsgEventType.USER_ERR | \
+                 AuditMsgEventType.CRED_ACQ | AuditMsgEventType.CRED_REFR | \
+                 AuditMsgEventType.CRED_DISP:
+                event_data['auth_action'] = type_name
+                event_data.update(fields)
+                event = AuditEvent.CREDENTIAL
+                username = fields.get('username') or fields.get('acct')
+                if username:
+                    user = username
+                addr_val = fields.get('addr')
+                if addr_val and addr_val not in AUDITD_NULL_VALUES:
+                    addr = addr_val
+                if 'res' in fields and isinstance(fields['res'], bool):
+                    success = fields['res']
+
+            case AuditMsgEventType.TTY:
+                event_data['tty_record'] = fields
+                event = AuditEvent.TTY_RECORD
+                username = fields.get('username')
+                if username and username not in AUDITD_NULL_VALUES:
+                    user = username
+
+            case _:
+                pass
+
+    # If we have a key_event (SYSCALL with key) and no user yet, extract from it
+    if key_event_parts and not user:
+        for record in parsed.get('records', []):
+            if record.get('type_name') == AuditMsgEventType.SYSCALL:
+                uid_str = record.get('fields', {}).get('UID')
+                if uid_str:
+                    user = uid_str
+                break
+
+    return {
+        'event': event.upper() if isinstance(event, str) else str(event).upper(),
+        'event_data': event_data,
+        'user': user,
+        'success': success,
+        'addr': addr,
+    }
+
+
+def audit_entry_to_json(
+    msgid: str,
+    event_type: AuditEvent | None,
+    raw_lines: list[str],
+    key_event_parts: list[str] | None = None,
+    parsed: dict | None = None,
+) -> str:
+    """Build TNAUDIT JSON string from audit entry data.
+
+    Args:
+        msgid: The audit message ID string (e.g., 'audit(1734419821.939:3615)')
+        event_type: The classified event type, or None for generic
+        raw_lines: Raw audit message lines
+        key_event_parts: Split parts of the key SYSCALL line, if any
+        parsed: Pre-parsed event dict (if None, raw_lines will be parsed)
+
+    Returns:
+        '@cee:' prefixed JSON string for syslog
+    """
+    aid, time_str = parse_msgid(msgid)
+
+    if parsed is None:
+        parsed = parse_multipart_event(raw_lines)
+    generated = _generate_event_data(parsed, event_type, raw_lines, key_event_parts)
+
+    event_data_dict = generated['event_data']
+
+    # Old handler: only events with a keyed SYSCALL (key_event set) had
+    # audit_msg_id_str and raw_lines=None in event_data.
+    if key_event_parts is not None:
+        event_data_dict['audit_msg_id_str'] = msgid
+        event_data_dict['raw_lines'] = None
+
+    to_write = {'TNAUDIT': {
+        'aid': aid,
+        'vers': {'major': 0, 'minor': 1},
+        'addr': generated['addr'],
+        'user': generated['user'],
+        'sess': None,
+        'time': time_str,
+        'svc': 'SYSTEM',
+        'svc_data': JSON_NULL,
+        'event': generated['event'],
+        'event_data': dumps(event_data_dict),
+        'success': generated['success'],
+    }}
+
+    return '@cee:' + dumps(to_write)

--- a/src/truenas_audit_parse/parsers.py
+++ b/src/truenas_audit_parse/parsers.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+import truenas_auparse
+from types import MappingProxyType
+
+from .constants import AUDITD_NULL_VALUES, PAM_MSG_TYPES, SERVICE_MSG_TYPES
+from .event_types import AuditEvent, AuditMsgEventType
+
+
+def parse_multipart_event(raw_lines: list[str]) -> dict:
+    """Parse multiple audit record lines into a structured dict using libauparse.
+
+    Joins lines with newlines and feeds them to the C extension for parsing.
+
+    Returns:
+        dict with 'records' key containing list of parsed record dicts.
+    """
+    combined = '\n'.join(raw_lines)
+    return truenas_auparse.parse_event(combined)
+
+
+def classify_event(parsed: dict) -> AuditEvent:
+    """Determine the AuditEvent type from parsed records.
+
+    Reads the 'key' field from SYSCALL records, or determines type from
+    LOGIN, SERVICE, PAM, or TTY records.
+    """
+    for record in parsed.get('records', []):
+        type_name = record.get('type_name', '')
+        fields = record.get('fields', {})
+
+        if type_name == AuditMsgEventType.SYSCALL:
+            key = fields.get('key')
+            if key is None or key in AUDITD_NULL_VALUES:
+                return AuditEvent.GENERIC
+            try:
+                return AuditEvent(key)
+            except ValueError:
+                return AuditEvent.GENERIC
+
+        if type_name == AuditMsgEventType.LOGIN:
+            return AuditEvent.LOGIN
+
+        if type_name in SERVICE_MSG_TYPES:
+            return AuditEvent.SERVICE
+
+        if type_name in PAM_MSG_TYPES:
+            return AuditEvent.CREDENTIAL
+
+        if type_name == AuditMsgEventType.TTY:
+            return AuditEvent.TTY_RECORD
+
+    return AuditEvent.GENERIC
+
+
+def _null_if_empty(value: str | None) -> str | None:
+    """Convert auditd null-equivalent strings to None."""
+    if value is None or value in AUDITD_NULL_VALUES:
+        return None
+    return value
+
+
+def _raw_int(raw_fields: dict, key: str) -> int | None:
+    """Get a raw field value as int, returning None on failure."""
+    value = raw_fields.get(key)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_bool_success(value: str | None) -> bool:
+    """Convert success field to boolean."""
+    if value is None:
+        return False
+    return value.lower() in ('yes', 'success', '1')
+
+
+def process_syscall(fields: dict, raw_fields: dict | None = None) -> dict:
+    """Post-process SYSCALL record fields for TNAUDIT output.
+
+    Matches the old handler's AuditMsgSyscall field subset:
+    success, exit, ppid, pid, auid, uid, gid, euid, suid, fsuid,
+    egid, sgid, fsgid, tty, ses, key, SYSCALL, AUID, UID, GID
+    """
+    if raw_fields is None:
+        raw_fields = {}
+
+    result = {}
+
+    # Bool field
+    if 'success' in fields:
+        result['success'] = _to_bool_success(fields['success'])
+
+    # Int fields from raw values (old handler used positional raw extraction)
+    for k in ('exit', 'ppid', 'pid', 'auid', 'uid', 'gid',
+              'euid', 'suid', 'fsuid', 'egid', 'sgid', 'fsgid',
+              'ses'):
+        if k in fields:
+            result[k] = _raw_int(raw_fields, k)
+
+    # String fields
+    if 'tty' in fields:
+        result['tty'] = _null_if_empty(fields['tty'])
+    if 'key' in fields:
+        result['key'] = _null_if_empty(fields['key'])
+
+    # Interpreted uppercase fields (old handler extracted these by position)
+    for k in ('SYSCALL', 'AUID', 'UID', 'GID'):
+        if k in fields:
+            result[k] = _null_if_empty(fields[k])
+
+    return result
+
+
+def process_path(fields: dict, raw_fields: dict | None = None) -> dict:
+    """Post-process PATH record fields for TNAUDIT output.
+
+    Matches the old handler's AuditMsgPath field subset:
+    name, inode, dev, mode, ouid, ogid, rdev, nametype
+    """
+    if raw_fields is None:
+        raw_fields = {}
+
+    result = {}
+
+    # String fields (use raw for mode to preserve octal format)
+    if 'name' in fields:
+        result['name'] = _null_if_empty(fields['name'])
+    if 'dev' in fields:
+        result['dev'] = _null_if_empty(raw_fields.get('dev', fields.get('dev')))
+    if 'mode' in fields:
+        result['mode'] = _null_if_empty(raw_fields.get('mode', fields.get('mode')))
+    if 'rdev' in fields:
+        result['rdev'] = _null_if_empty(raw_fields.get('rdev', fields.get('rdev')))
+    if 'nametype' in fields:
+        result['nametype'] = _null_if_empty(fields['nametype'])
+
+    # Int fields from raw
+    if 'inode' in fields:
+        result['inode'] = _raw_int(raw_fields, 'inode')
+    if 'ouid' in fields:
+        result['ouid'] = _raw_int(raw_fields, 'ouid')
+    if 'ogid' in fields:
+        result['ogid'] = _raw_int(raw_fields, 'ogid')
+
+    return result
+
+
+def process_login(fields: dict, raw_fields: dict | None = None) -> dict:
+    """Post-process LOGIN record fields for TNAUDIT output.
+
+    Matches the old handler's AuditMsgLogin field subset:
+    old-auid, auid, tty, old-ses, ses, res
+    """
+    if raw_fields is None:
+        raw_fields = {}
+
+    result = {}
+    for k in ('old-auid', 'auid', 'old-ses', 'ses', 'res'):
+        if k in fields:
+            result[k] = _raw_int(raw_fields, k)
+    if 'tty' in fields:
+        result['tty'] = _null_if_empty(fields['tty'])
+
+    return result
+
+
+def process_service(fields: dict, raw_fields: dict | None = None) -> dict:
+    """Post-process SERVICE_START/SERVICE_STOP record fields.
+
+    Matches the old handler's AuditMsgService field subset:
+    subj, unit, comm, exe, res
+    """
+    result = {}
+    if 'subj' in fields:
+        result['subj'] = _null_if_empty(fields['subj'])
+    if 'unit' in fields:
+        result['unit'] = _null_if_empty(fields['unit'])
+    if 'comm' in fields:
+        result['comm'] = _null_if_empty(fields['comm'])
+    if 'exe' in fields:
+        result['exe'] = _null_if_empty(fields['exe'])
+    if 'res' in fields:
+        result['res'] = _to_bool_success(fields['res'])
+    return result
+
+
+def process_pam(fields: dict, raw_fields: dict | None = None) -> dict:
+    """Post-process PAM-related record fields (USER_*, CRED_*).
+
+    Matches the old handler's PAM field subset:
+    pid, function, grantors, acct, exe, hostname, addr, terminal, res, username
+    """
+    if raw_fields is None:
+        raw_fields = {}
+
+    result = {}
+
+    if 'pid' in fields:
+        result['pid'] = _raw_int(raw_fields, 'pid')
+
+    # Old handler called this 'function', auparse calls it 'op'
+    if 'op' in fields:
+        result['function'] = _null_if_empty(fields['op'])
+
+    for k in ('grantors', 'acct', 'exe', 'hostname', 'terminal'):
+        if k in fields:
+            result[k] = _null_if_empty(fields[k])
+
+    if 'addr' in fields:
+        result['addr'] = _null_if_empty(fields['addr'])
+
+    if 'res' in fields:
+        result['res'] = _to_bool_success(fields['res'])
+
+    # AUID → username (old handler mapped AUID key to 'username')
+    if 'AUID' in fields:
+        result['username'] = _null_if_empty(fields['AUID'])
+
+    return result
+
+
+def process_tty(fields: dict, raw_fields: dict | None = None) -> dict:
+    """Post-process TTY record fields."""
+    if raw_fields is None:
+        raw_fields = {}
+
+    result = {}
+    for k in ('pid', 'uid', 'ses', 'major', 'minor'):
+        if k in fields:
+            result[k] = _raw_int(raw_fields, k)
+    if 'comm' in fields:
+        result['comm'] = _null_if_empty(fields['comm'])
+    if 'data' in fields:
+        result['data'] = _null_if_empty(fields['data'])
+    # Old handler mapped AUID_STR to 'username'
+    if 'AUID' in fields:
+        result['username'] = _null_if_empty(fields['AUID'])
+
+    return result
+
+
+RECORD_PROCESSORS = MappingProxyType({
+    AuditMsgEventType.SYSCALL: process_syscall,
+    AuditMsgEventType.PATH: process_path,
+    AuditMsgEventType.LOGIN: process_login,
+    AuditMsgEventType.SERVICE_START: process_service,
+    AuditMsgEventType.SERVICE_STOP: process_service,
+    AuditMsgEventType.TTY: process_tty,
+    AuditMsgEventType.USER_START: process_pam,
+    AuditMsgEventType.USER_END: process_pam,
+    AuditMsgEventType.USER_ACCT: process_pam,
+    AuditMsgEventType.USER_AUTH: process_pam,
+    AuditMsgEventType.USER_LOGIN: process_pam,
+    AuditMsgEventType.USER_ERR: process_pam,
+    AuditMsgEventType.CRED_ACQ: process_pam,
+    AuditMsgEventType.CRED_REFR: process_pam,
+    AuditMsgEventType.CRED_DISP: process_pam,
+})

--- a/stubs/__init__.pyi
+++ b/stubs/__init__.pyi
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+from typing import Callable
+
+def parse_event(raw_text: str) -> dict[str, list[dict[str, int | str | dict[str, str]]]]:
+    """Parse audit event text using libauparse.
+
+    Takes one or more newline-separated audit records and returns
+    a dict with interpreted field values.
+
+    Parameters
+    ----------
+    raw_text : str
+        Raw audit event text (one or more records, newline-separated)
+
+    Returns
+    -------
+    dict
+        {'records': [{'type': int, 'type_name': str, 'fields': {name: value, ...}}, ...]}
+    """
+    ...
+
+def get_record_type(raw_text: str) -> str:
+    """Get the record type name from the first record in raw audit text.
+
+    Parameters
+    ----------
+    raw_text : str
+        Raw audit record text
+
+    Returns
+    -------
+    str
+        Record type name (e.g., 'SYSCALL', 'PATH', 'LOGIN')
+    """
+    ...
+
+class AuparseContext:
+    """Streaming audit event parser using libauparse feed+callback model."""
+    def __init__(self, callback: Callable[[dict], None]) -> None: ...
+    def feed(self, line: str) -> None: ...
+    def flush(self) -> None: ...

--- a/systemd/tnaudit.service
+++ b/systemd/tnaudit.service
@@ -8,7 +8,7 @@ After=auditd.service
 
 [Service]
 Type=exec
-ExecStart=/usr/local/libexec/truenas_audit_handler.py
+ExecStart=/usr/bin/truenas_audit_handler
 SendSIGKILL=no
 MemoryDenyWriteExecute=true
 LockPersonality=true

--- a/tests/test_cext.py
+++ b/tests/test_cext.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+import pytest
+import truenas_auparse
+
+
+SAMPLE_SYSCALL = (
+    'type=SYSCALL msg=audit(1734547436.320:852): arch=c000003e syscall=59 '
+    'success=yes exit=0 a0=7fb27f458c70 a1=7fb27f458ce0 a2=56289c566760 '
+    'a3=8 items=4 ppid=10424 pid=11969 auid=0 uid=0 gid=0 euid=0 suid=0 '
+    'fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts2 ses=12 '
+    'comm="disable-rootfs-" exe="/usr/bin/python3.11" subj=unconfined '
+    'key="escalation" ARCH=x86_64 SYSCALL=execve AUID="root" UID="root" '
+    'GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" '
+    'SGID="root" FSGID="root"'
+)
+
+SAMPLE_PATH = (
+    'type=PATH msg=audit(1734547436.320:852): item=1 '
+    'name="/usr/local/libexec/disable-rootfs-protection" inode=46471 '
+    'dev=00:23 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL '
+    'cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0 '
+    'OUID="root" OGID="root"'
+)
+
+SAMPLE_PROCTITLE = (
+    'type=PROCTITLE msg=audit(1734547436.320:852): '
+    'proctitle=2F7573722F62696E2F707974686F6E33002F7573722F6C6F63616C2F'
+    '6C6962657865632F64697361626C652D726F6F7466732D70726F74656374696F6E'
+)
+
+SAMPLE_CWD = 'type=CWD msg=audit(1734547436.320:852): cwd="/root"'
+
+SAMPLE_LOGIN = (
+    'type=LOGIN msg=audit(1735069956.674:1968): pid=38804 uid=0 '
+    'subj=unconfined old-auid=4294967295 auid=0 tty=(none) '
+    'old-ses=4294967295 ses=28 res=1 UID="root" OLD-AUID="unset" AUID="root"'
+)
+
+SAMPLE_EOE = 'type=EOE msg=audit(1734547436.320:852): '
+
+
+class TestParseEvent:
+    def test_syscall_record(self):
+        result = truenas_auparse.parse_event(SAMPLE_SYSCALL)
+        assert 'records' in result
+        assert len(result['records']) == 1
+
+        record = result['records'][0]
+        assert record['type_name'] == 'SYSCALL'
+        assert 'fields' in record
+
+        fields = record['fields']
+        assert 'key' in fields
+        assert 'pid' in fields
+        assert 'uid' in fields
+
+    def test_path_record(self):
+        result = truenas_auparse.parse_event(SAMPLE_PATH)
+        assert len(result['records']) == 1
+
+        record = result['records'][0]
+        assert record['type_name'] == 'PATH'
+        assert 'name' in record['fields']
+
+    def test_multirecord_event(self):
+        combined = '\n'.join([SAMPLE_SYSCALL, SAMPLE_PATH, SAMPLE_CWD, SAMPLE_PROCTITLE])
+        result = truenas_auparse.parse_event(combined)
+        assert len(result['records']) == 4
+
+        type_names = [r['type_name'] for r in result['records']]
+        assert 'SYSCALL' in type_names
+        assert 'PATH' in type_names
+        assert 'CWD' in type_names
+        assert 'PROCTITLE' in type_names
+
+    def test_login_record(self):
+        result = truenas_auparse.parse_event(SAMPLE_LOGIN)
+        assert len(result['records']) == 1
+        assert result['records'][0]['type_name'] == 'LOGIN'
+
+    def test_empty_input(self):
+        result = truenas_auparse.parse_event('')
+        assert result['records'] == []
+
+    def test_invalid_type(self):
+        with pytest.raises(TypeError):
+            truenas_auparse.parse_event(123)
+
+
+class TestGetRecordType:
+    def test_syscall_type(self):
+        assert truenas_auparse.get_record_type(SAMPLE_SYSCALL) == 'SYSCALL'
+
+    def test_path_type(self):
+        assert truenas_auparse.get_record_type(SAMPLE_PATH) == 'PATH'
+
+    def test_login_type(self):
+        assert truenas_auparse.get_record_type(SAMPLE_LOGIN) == 'LOGIN'
+
+    def test_cwd_type(self):
+        assert truenas_auparse.get_record_type(SAMPLE_CWD) == 'CWD'
+
+    def test_proctitle_type(self):
+        assert truenas_auparse.get_record_type(SAMPLE_PROCTITLE) == 'PROCTITLE'
+
+    def test_eoe_type(self):
+        assert truenas_auparse.get_record_type(SAMPLE_EOE) == 'EOE'
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            truenas_auparse.get_record_type('')
+
+
+class TestAuparseContext:
+    def test_create_context(self):
+        ctx = truenas_auparse.AuparseContext(callback=lambda ev: None)
+        assert ctx is not None
+
+    def test_callback_not_callable(self):
+        with pytest.raises(TypeError):
+            truenas_auparse.AuparseContext(callback="not callable")
+
+    def test_multipart_event(self):
+        events = []
+        ctx = truenas_auparse.AuparseContext(callback=events.append)
+
+        ctx.feed(SAMPLE_SYSCALL)
+        ctx.feed(SAMPLE_PATH)
+        ctx.feed(SAMPLE_CWD)
+        ctx.feed(SAMPLE_PROCTITLE)
+        ctx.feed(SAMPLE_EOE)
+
+        assert len(events) == 1
+        event = events[0]
+        assert 'records' in event
+        type_names = [r['type_name'] for r in event['records']]
+        assert 'SYSCALL' in type_names
+        assert 'PATH' in type_names
+        assert 'CWD' in type_names
+        assert 'PROCTITLE' in type_names
+
+    def test_eoe_triggers_callback(self):
+        """Callback fires when event is flushed after EOE."""
+        events = []
+        ctx = truenas_auparse.AuparseContext(callback=events.append)
+
+        ctx.feed(SAMPLE_SYSCALL)
+        assert len(events) == 0
+
+        ctx.feed(SAMPLE_EOE)
+        ctx.flush()
+        assert len(events) == 1
+
+    def test_raw_lines_and_msgid(self):
+        events = []
+        ctx = truenas_auparse.AuparseContext(callback=events.append)
+
+        ctx.feed(SAMPLE_SYSCALL)
+        ctx.feed(SAMPLE_EOE)
+        ctx.flush()
+
+        assert len(events) == 1
+        event = events[0]
+        assert 'raw_lines' in event
+        assert 'msgid' in event
+        assert len(event['raw_lines']) > 0
+        assert 'audit(' in event['msgid']
+
+    def test_flush_incomplete(self):
+        events = []
+        ctx = truenas_auparse.AuparseContext(callback=events.append)
+
+        ctx.feed(SAMPLE_SYSCALL)
+        assert len(events) == 0
+
+        ctx.flush()
+        assert len(events) == 1
+
+    def test_next_event_triggers_previous(self):
+        """Feeding a new event triggers callback for the previous one."""
+        events = []
+        ctx = truenas_auparse.AuparseContext(callback=events.append)
+
+        # First event
+        ctx.feed(SAMPLE_SYSCALL)
+        ctx.feed(SAMPLE_EOE)
+        assert len(events) == 0
+
+        # LOGIN is a complete single-record event; libauparse fires both
+        # the previous SYSCALL event and the LOGIN event immediately
+        ctx.feed(SAMPLE_LOGIN)
+        assert len(events) == 2
+
+        ctx.flush()
+        assert len(events) == 2
+
+    def test_multiple_events(self):
+        events = []
+        ctx = truenas_auparse.AuparseContext(callback=events.append)
+
+        # First event
+        ctx.feed(SAMPLE_SYSCALL)
+        ctx.feed(SAMPLE_EOE)
+        # Second event
+        ctx.feed(SAMPLE_LOGIN)
+        ctx.feed('type=EOE msg=audit(1735069956.674:1968): ')
+        ctx.flush()
+
+        assert len(events) == 2
+
+    def test_callback_exception_propagates(self):
+        def bad_callback(ev):
+            raise ValueError("test error")
+
+        ctx = truenas_auparse.AuparseContext(callback=bad_callback)
+
+        with pytest.raises(ValueError, match="test error"):
+            ctx.feed(SAMPLE_SYSCALL)
+            ctx.feed(SAMPLE_EOE)
+            ctx.flush()
+
+    def test_gc_does_not_crash(self):
+        """AuparseContext is GC-tracked and does not corrupt the collector."""
+        import gc
+
+        truenas_auparse.AuparseContext(callback=lambda ev: None)
+        gc.collect()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+import json
+import pytest
+from truenas_audit_parse.formatter import parse_msgid, audit_entry_to_json
+from truenas_audit_parse.event_types import AuditEvent
+
+
+SAMPLE_MSGID = 'audit(1734547436.320:852)'
+
+SAMPLE_SYSCALL = (
+    'type=SYSCALL msg=audit(1734547436.320:852): arch=c000003e syscall=59 '
+    'success=yes exit=0 a0=7fb27f458c70 a1=7fb27f458ce0 a2=56289c566760 '
+    'a3=8 items=4 ppid=10424 pid=11969 auid=0 uid=0 gid=0 euid=0 suid=0 '
+    'fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts2 ses=12 '
+    'comm="disable-rootfs-" exe="/usr/bin/python3.11" subj=unconfined '
+    'key="escalation" ARCH=x86_64 SYSCALL=execve AUID="root" UID="root" '
+    'GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" '
+    'SGID="root" FSGID="root"'
+)
+
+SAMPLE_CWD = 'type=CWD msg=audit(1734547436.320:852): cwd="/root"'
+
+SAMPLE_PROCTITLE = (
+    'type=PROCTITLE msg=audit(1734547436.320:852): '
+    'proctitle=2F7573722F62696E2F707974686F6E33002F7573722F6C6F63616C2F'
+    '6C6962657865632F64697361626C652D726F6F7466732D70726F74656374696F6E'
+)
+
+
+class TestParseMsgid:
+    def test_basic_parsing(self):
+        aid, time_str = parse_msgid(SAMPLE_MSGID)
+        # Should be a valid UUID string
+        assert len(aid) == 36
+        assert aid.count('-') == 4
+        # Should contain a reasonable timestamp
+        assert '2024-12-18' in time_str
+
+    def test_uuid_uniqueness(self):
+        # Random bits should make each call produce a different UUID
+        aid1, _ = parse_msgid(SAMPLE_MSGID)
+        aid2, _ = parse_msgid(SAMPLE_MSGID)
+        assert aid1 != aid2
+
+
+class TestAuditEntryToJson:
+    def test_basic_json_structure(self):
+        result = audit_entry_to_json(
+            SAMPLE_MSGID,
+            AuditEvent.ESCALATION,
+            [SAMPLE_SYSCALL, SAMPLE_CWD, SAMPLE_PROCTITLE],
+        )
+        assert result.startswith('@cee:')
+        payload = json.loads(result[5:])
+        tnaudit = payload['TNAUDIT']
+
+        assert 'aid' in tnaudit
+        assert tnaudit['vers'] == {'major': 0, 'minor': 1}
+        assert tnaudit['svc'] == 'SYSTEM'
+        assert 'time' in tnaudit
+        assert 'event_data' in tnaudit
+
+    def test_event_data_is_json_string(self):
+        # key_event_parts triggers audit_msg_id_str inclusion
+        syscall_parts = SAMPLE_SYSCALL.split()
+        result = audit_entry_to_json(
+            SAMPLE_MSGID,
+            AuditEvent.ESCALATION,
+            [SAMPLE_SYSCALL],
+            key_event_parts=syscall_parts,
+        )
+        payload = json.loads(result[5:])
+        # event_data should be a JSON string (double-encoded)
+        event_data = json.loads(payload['TNAUDIT']['event_data'])
+        assert isinstance(event_data, dict)
+        assert 'audit_msg_id_str' in event_data
+
+    def test_null_event_type(self):
+        result = audit_entry_to_json(
+            SAMPLE_MSGID,
+            None,
+            [SAMPLE_SYSCALL],
+        )
+        payload = json.loads(result[5:])
+        assert 'event' in payload['TNAUDIT']

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) TrueNAS, 2026
+
+import pytest
+from truenas_audit_parse.parsers import (
+    classify_event,
+    parse_multipart_event,
+    process_syscall,
+    process_path,
+    process_login,
+    process_service,
+    process_pam,
+    process_tty,
+)
+from truenas_audit_parse.event_types import AuditEvent
+
+
+SAMPLE_SYSCALL = (
+    'type=SYSCALL msg=audit(1734547436.320:852): arch=c000003e syscall=59 '
+    'success=yes exit=0 a0=7fb27f458c70 a1=7fb27f458ce0 a2=56289c566760 '
+    'a3=8 items=4 ppid=10424 pid=11969 auid=0 uid=0 gid=0 euid=0 suid=0 '
+    'fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts2 ses=12 '
+    'comm="disable-rootfs-" exe="/usr/bin/python3.11" subj=unconfined '
+    'key="escalation" ARCH=x86_64 SYSCALL=execve AUID="root" UID="root" '
+    'GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" '
+    'SGID="root" FSGID="root"'
+)
+
+SAMPLE_LOGIN = (
+    'type=LOGIN msg=audit(1735069956.674:1968): pid=38804 uid=0 '
+    'subj=unconfined old-auid=4294967295 auid=0 tty=(none) '
+    'old-ses=4294967295 ses=28 res=1 UID="root" OLD-AUID="unset" AUID="root"'
+)
+
+SAMPLE_SERVICE = (
+    'type=SERVICE_START msg=audit(1736973663.599:429): pid=1 uid=0 '
+    'auid=4294967295 ses=4294967295 subj=unconfined '
+    "msg='unit=smbd comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" "
+    "hostname=? addr=? terminal=? res=success' "
+    'UID="root" AUID="unset"'
+)
+
+
+class TestClassifyEvent:
+    def test_syscall_escalation(self):
+        parsed = parse_multipart_event([SAMPLE_SYSCALL])
+        assert classify_event(parsed) == AuditEvent.ESCALATION
+
+    def test_login_event(self):
+        parsed = parse_multipart_event([SAMPLE_LOGIN])
+        assert classify_event(parsed) == AuditEvent.LOGIN
+
+    def test_service_event(self):
+        parsed = parse_multipart_event([SAMPLE_SERVICE])
+        assert classify_event(parsed) == AuditEvent.SERVICE
+
+    def test_empty_records(self):
+        assert classify_event({'records': []}) == AuditEvent.GENERIC
+
+
+class TestProcessSyscall:
+    def test_success_conversion(self):
+        fields = {'success': 'yes', 'pid': 'root', 'exit': '0'}
+        raw = {'success': 'yes', 'pid': '1234', 'exit': '0'}
+        result = process_syscall(fields, raw)
+        assert result['success'] is True
+        assert result['pid'] == 1234
+        assert result['exit'] == 0
+
+    def test_failure_conversion(self):
+        fields = {'success': 'no', 'pid': 'root'}
+        raw = {'success': 'no', 'pid': '5678'}
+        result = process_syscall(fields, raw)
+        assert result['success'] is False
+
+
+class TestProcessPath:
+    def test_int_conversion(self):
+        fields = {'inode': '46471', 'ouid': 'root', 'ogid': 'root', 'name': '/tmp/test'}
+        raw = {'inode': '46471', 'ouid': '0', 'ogid': '0', 'name': '/tmp/test'}
+        result = process_path(fields, raw)
+        assert result['inode'] == 46471
+        assert result['ouid'] == 0
+        assert result['name'] == '/tmp/test'
+
+
+class TestProcessLogin:
+    def test_int_fields(self):
+        fields = {'ses': 'root', 'res': '1'}
+        raw = {'ses': '28', 'res': '1'}
+        result = process_login(fields, raw)
+        assert result['ses'] == 28
+        assert result['res'] == 1
+
+
+class TestProcessService:
+    def test_res_conversion(self):
+        result = process_service({'res': 'success', 'unit': 'smbd'})
+        assert result['res'] is True
+        assert result['unit'] == 'smbd'
+
+
+class TestProcessPam:
+    def test_username_extraction(self):
+        fields = {'pid': 'root', 'AUID': 'root', 'res': 'success'}
+        raw = {'pid': '1234', 'AUID': '"root"', 'res': 'success'}
+        result = process_pam(fields, raw)
+        assert result['pid'] == 1234
+        assert result['username'] == 'root'
+        assert result['res'] is True
+
+    def test_uid_skipped(self):
+        result = process_pam({'UID': 'root', 'ID': 'root'})
+        assert 'UID' not in result
+        assert 'ID' not in result
+
+
+class TestProcessTty:
+    def test_int_fields(self):
+        fields = {'pid': 'root', 'uid': 'root', 'ses': '16', 'major': '136', 'minor': '1'}
+        raw = {'pid': '28250', 'uid': '0', 'ses': '16', 'major': '136', 'minor': '1'}
+        result = process_tty(fields, raw)
+        assert result['pid'] == 28250
+        assert result['ses'] == 16


### PR DESCRIPTION
This commit converts our basic audit parser to use libauparse on backend. Event parsing is now two
stages.

1) feed into auparse and let it do entry aggregation and first pass through parsing into fields

2) pass to the JSON event parser that then takes the auditd record and converts it into the format we expect for DB insertion.

This revised approach to parsing should make the
general audit parsing more sustainable in the long term.